### PR TITLE
pre-check-command

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,1 +1,4 @@
 *out
+*logs
+external
+plugins

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.11.0-beta
+  version: 0.16.1-beta
 repo:
   repo:
     host: github.com

--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,10 @@ inputs:
       name.
     required: false
 
+  pre-check-command:
+    description: Additional command to run after `trunk install` and before `trunk check`.
+    required: false
+
 runs:
   using: composite
   steps:
@@ -92,6 +96,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         INPUT_ARGUMENTS: ${{ inputs.arguments }}
         INPUT_LABEL: ${{ inputs.label }}
+        PRE_CHECK_COMMAND: ${{ inputs.pre-check-command }}
 
     - name: Run trunk check on push
       if: env.TRUNK_CHECK_MODE == 'push'
@@ -107,6 +112,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         INPUT_ARGUMENTS: ${{ inputs.arguments }}
         INPUT_LABEL: ${{ inputs.label }}
+        PRE_CHECK_COMMAND: ${{ inputs.pre-check-command }}
 
     - name: Run trunk check on all
       if: env.TRUNK_CHECK_MODE == 'all'
@@ -123,6 +129,7 @@ runs:
         INPUT_LABEL: ${{ inputs.label }}
         INPUT_TRUNK_TOKEN: ${{ inputs.trunk-token }}
         INPUT_UPLOAD_SERIES: ${{ inputs.upload-series }}
+        PRE_CHECK_COMMAND: ${{ inputs.pre-check-command }}
 
     - name: Run trunk check on Trunk Merge
       if: env.TRUNK_CHECK_MODE == 'trunk_merge'
@@ -136,6 +143,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         INPUT_ARGUMENTS: ${{ inputs.arguments }}
         INPUT_LABEL: ${{ inputs.label }}
+        PRE_CHECK_COMMAND: ${{ inputs.pre-check-command }}
 
     - name: Cleanup temporary files
       if: always()

--- a/all.sh
+++ b/all.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+"${TRUNK_PATH}" install \
+  --ci
+
+if [[ -n ${PRE_CHECK_COMMAND} ]]; then
+  eval ${PRE_CHECK_COMMAND}
+fi
+
 if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
   "${TRUNK_PATH}" check \
     --ci \

--- a/pull_request.sh
+++ b/pull_request.sh
@@ -26,6 +26,13 @@ if [[ -z ${upstream+x} ]]; then
   fetch origin "${upstream}"
 fi
 
+"${TRUNK_PATH}" install \
+  --ci
+
+if [[ -n ${PRE_CHECK_COMMAND} ]]; then
+  eval ${PRE_CHECK_COMMAND}
+fi
+
 "${TRUNK_PATH}" check \
   --ci \
   --upstream "${upstream}" \

--- a/push.sh
+++ b/push.sh
@@ -25,6 +25,13 @@ if [[ -z ${upstream+x} ]]; then
   fetch origin "${upstream}"
 fi
 
+"${TRUNK_PATH}" install \
+  --ci
+
+if [[ -n ${PRE_CHECK_COMMAND} ]]; then
+  eval ${PRE_CHECK_COMMAND}
+fi
+
 "${TRUNK_PATH}" check \
   --ci \
   --upstream "${upstream}" \

--- a/readme.md
+++ b/readme.md
@@ -233,6 +233,17 @@ If you'd like to run multiple Trunk Check jobs on different platforms at the sam
     arguments: --github-label=${{ runner.os }}
 ```
 
+## Running additional command before check
+
+If need to run additional command before check, you can add:
+
+```yaml
+- name: Trunk Check
+  uses: trunk-io/trunk-action@v1
+  with:
+    pre-check-command: ~/.cache/trunk/linters/terraform/1.2.8-*/terraform init
+```
+
 ## Annotating existing issues
 
 By default the Trunk Action will only annotate new issues, but if you also want to annotate existing

--- a/trunk_merge.sh
+++ b/trunk_merge.sh
@@ -16,6 +16,13 @@ fetch --depth=2 origin "${head_sha}"
 upstream=$(git rev-parse HEAD^1)
 echo "Detected merge queue commit, using HEAD^1 (${upstream}) as upstream"
 
+"${TRUNK_PATH}" install \
+  --ci
+
+if [[ -n ${PRE_CHECK_COMMAND} ]]; then
+  eval ${PRE_CHECK_COMMAND}
+fi
+
 "${TRUNK_PATH}" check \
   --ci \
   --upstream "${upstream}" \


### PR DESCRIPTION
Hi. This additional argument allows to inject the command run before `trunk check` is called. Most useful is to run `terraform init` when `terraform` plugin is used.

Unfortunately `trunk install --ci` is broken and has too verbose progress bar.
