### PR TITLE
Update cache action to version 3

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
   steps:
     - name: Cache Linters/Formatters
       if: inputs.cache == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/trunk
         key: trunk-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}


### PR DESCRIPTION
Update the action actions/cache  to version 3 because it is using a deprecated version of NodeJs and using the save-state  and set-output commands