### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Trunk Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I want to use the [devcontainers/ci](https://github.com/devcontainers/ci/blob/main/README.md)  action to run trunk check inside a dev container, but the official Trunk action can only be run on a standard GitHub Actions runner. As a result, I need to manually install Trunk and its dependencies, and invoke Trunk in a manner similar to the [pull_request.sh](https://github.com/trunk-io/trunk-action/blob/main/pull_request.sh) script. I am creating a custom `trunk-check.sh` script to handle this process, and I am using this repository as a reference for my implementation.

I want to credit you properly, with copyright and license information included. However, since this repository does not have a `LICENSE` file, the code is not open source (cf. [Choose a License: No License](https://choosealicense.com/no-permission/)). However, I noticed that you seem to use the MIT license in your other repositories, so this pull request adds the MIT license to this repository.