### PR TITLE
chore(renovate): allow auto-merging

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
   prConcurrentLimit: 3,
   packageRules: [
     {
+      automerge: true,
       groupName: "all non-major dependencies",
       groupSlug: "all-minor-patch",
       matchPackagePatterns: ["*"],


### PR DESCRIPTION
Renovate PRs should just get merged when a reviewer approves.