### PR TITLE
Revert "feat: allow node_modules set up to fail"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -134,12 +134,10 @@ runs:
       uses: pnpm/action-setup@v2
       with:
         version: latest
-      continue-on-error: true
 
     - name: Install Node dependencies
       if: steps.detect.outputs.package_manager
       uses: actions/setup-node@v3
-      continue-on-error: true
 
     #- name: Cache node_modules
     #  uses: actions/cache@v3
@@ -151,13 +149,11 @@ runs:
       if: steps.detect.outputs.package_manager
       shell: bash
       run: ${{ steps.detect.outputs.install_cmd }}
-      continue-on-error: true
 
     - name: Post-init steps
       if: inputs.post-init
       shell: bash
       run: ${{ inputs.post-init }}
-      continue-on-error: true
 
     - name: Determine check mode
       shell: bash


### PR DESCRIPTION
Reverts trunk-io/trunk-action#59

Bizarrely, this appears to be causing issues with `trunk check` - I don't understand how