### PR TITLE
feat: support finalizing the check run

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -292,7 +292,7 @@ runs:
           if (status === "completed") {
             return;
           }
-          await github.checks.update({
+          await github.rest.checks.update({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }},

--- a/action.yaml
+++ b/action.yaml
@@ -86,6 +86,7 @@ runs:
     - name: Env setup
       shell: bash
       run: |
+        echo "::add-mask::$INPUT_FINALIZE_TOKEN"
         echo "::add-mask::$INPUT_TRUNK_TOKEN"
 
         cat >>$GITHUB_ENV <<EOF
@@ -96,6 +97,7 @@ runs:
         INPUT_TRUNK_TOKEN=$INPUT_TRUNK_TOKEN
         EOF
       env:
+        INPUT_FINALIZE_TOKEN: ${{ inputs.finalize-token }}
         INPUT_TRUNK_TOKEN: ${{ inputs.trunk-token }}
 
     - name: Locate trunk
@@ -270,6 +272,35 @@ runs:
         ${GITHUB_ACTION_PATH}/annotate.sh
       env:
         GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+
+    - name: Finalize check run
+      if: always() #&& inputs.check-run-id
+      continue-on-error: true
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.finalize-token }}
+        script: |
+          const { status,  = await github.rest.checks.get({
+            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
+            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
+            ${{ inputs.check-run-id }}
+          });
+          if (status == "completed") {
+            return;
+          }
+          await github.checks.update({
+            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
+            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
+            check_run_id: ${{ inputs.check-run-id }},
+            head_sha: ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }},
+            status: "completed",
+            conclusion: "failure",
+            output: {
+              title: "Trunk Check",
+              summary: "unexpected failure",
+              text: "Please contact us at https://slack.trunk.io to get help",
+            },
+          });
 
     - name: Cleanup temporary files
       if: always()

--- a/action.yaml
+++ b/action.yaml
@@ -285,9 +285,9 @@ runs:
         github-token: ${{ inputs.github-token }}
         script: |
           const { status } = await github.rest.checks.get({
-            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
-            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
-            ${{ inputs.check-run-id }}
+            owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
+            repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
+            check_run_id: ${{ inputs.check-run-id }}
           });
           if (status === "completed") {
             return;

--- a/action.yaml
+++ b/action.yaml
@@ -289,7 +289,7 @@ runs:
             "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             ${{ inputs.check-run-id }}
           });
-          if (status == "completed") {
+          if (status === "completed") {
             return;
           }
           await github.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -284,7 +284,7 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const { status,  = await github.rest.checks.get({
+          const { status } = await github.rest.checks.get({
             "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             ${{ inputs.check-run-id }}

--- a/action.yaml
+++ b/action.yaml
@@ -296,7 +296,7 @@ runs:
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }},
-            head_sha: ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }},
+            head_sha: "${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }}",
             status: "completed",
             conclusion: "failure",
             output: {

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,10 @@ inputs:
     description: Steps to run after auto-init / before check
     required: false
 
+  github-token:
+    description: For overriding github.token
+    required: false
+
   trunk-token:
     description:
       You can find a per-repo API token in the Trunk web app settings. This will cause results to be
@@ -86,7 +90,7 @@ runs:
     - name: Env setup
       shell: bash
       run: |
-        echo "::add-mask::$INPUT_FINALIZE_TOKEN"
+        echo "::add-mask::$INPUT_GITHUB_TOKEN"
         echo "::add-mask::$INPUT_TRUNK_TOKEN"
 
         cat >>$GITHUB_ENV <<EOF
@@ -97,7 +101,7 @@ runs:
         INPUT_TRUNK_TOKEN=$INPUT_TRUNK_TOKEN
         EOF
       env:
-        INPUT_FINALIZE_TOKEN: ${{ inputs.finalize-token }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_TRUNK_TOKEN: ${{ inputs.trunk-token }}
 
     - name: Locate trunk
@@ -278,7 +282,7 @@ runs:
       continue-on-error: true
       uses: actions/github-script@v6
       with:
-        github-token: ${{ inputs.finalize-token }}
+        github-token: ${{ inputs.github-token }}
         script: |
           const { status,  = await github.rest.checks.get({
             "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",

--- a/action.yaml
+++ b/action.yaml
@@ -278,7 +278,7 @@ runs:
         GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
     - name: Finalize check run
-      if: always() #&& inputs.check-run-id
+      if: always() && inputs.check-run-id
       continue-on-error: true
       uses: actions/github-script@v6
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -293,8 +293,8 @@ runs:
             return;
           }
           await github.checks.update({
-            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
-            "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
+            owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
+            repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }},
             head_sha: ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }},
             status: "completed",


### PR DESCRIPTION
Mark the check run as failed if one was passed in and we didn't apply a final status to it. This will cover cases where the CLI crashes or the service RPCs fail.

[Manual test](https://github.com/prawn-test-staging-rw/check-web/pull/2294/checks?check_run_id=12411615007): 
![image](https://user-images.githubusercontent.com/512410/228986182-efb622a3-6535-4b1d-ae3a-b992389c00a5.png)
