### PR TITLE
fix: check-run-id finalization logic is wrong

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -291,6 +291,7 @@ runs:
           });
           console.log('check API returned', check);
           const { status } = check;
+          console.log('returned status is', status);
           if (status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -290,8 +290,8 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           console.log('check API returned', check);
-          const { data: { status } } = check;
-          console.log('returned status is', status);
+          const { data: { status: checkStatus } } = check;
+          console.log('returned status is', checkStatus);
           if (status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -284,11 +284,13 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const { status } = await github.rest.checks.get({
+          const check = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
+          console.log('check API returned', check);
+          const { status } = check;
           if (status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -284,14 +284,17 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const { data: { status: checkStatus } } = await github.rest.checks.get({
+          console.log("Verifying that the GitHub check run was updated with results...");
+          const { data } = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          if (checkStatus === "completed") {
+          if (data.status === "completed") {
+            console.log("Success!");
             return;
           }
+          console.log("Check was not completed; marking the check run as failed; details are ", data);
           await github.rest.checks.update({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",

--- a/action.yaml
+++ b/action.yaml
@@ -283,17 +283,13 @@ runs:
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}
-        # Both destructuring forms cause "SyntaxError: Invalid or unexpected token"
         script: |
-          const check = await github.rest.checks.get({
+          const { data: { status: checkStatus } } = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          const { data: { status: checkStatus } } = check;
-          const { data: { status } } = check;
-          console.log("try nested destructure", { status, checkStatus });
-          if (check.data.status === "completed") {
+          if (checkStatus === "completed") {
             return;
           }
           await github.rest.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -290,7 +290,7 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           console.log('check API returned', check);
-          const { status } = check;
+          const { data: { status } } = check;
           console.log('returned status is', status);
           if (status === "completed") {
             return;

--- a/action.yaml
+++ b/action.yaml
@@ -290,8 +290,8 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           # The below snippet doesn't work for destructuring, weirdly enough...
-          const { data: { status } } = check;
-            console.log('try nested destructure', status);
+          const { data: { status: checkStatus } } = check;
+          console.log("try nested destructure", checkStatus);
           if (check.data.status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -289,12 +289,7 @@ runs:
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          console.log('check API returned', check);
-          console.log('check API data', check.data);
-          console.log('check API status', check.data.status);
-          const { data: { status: checkStatus } } = check;
-          console.log('returned status is', checkStatus);
-          if (status === "completed") {
+          if (check.data.status === "completed") {
             return;
           }
           await github.rest.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -294,7 +294,9 @@ runs:
             console.log("Success!");
             //return;
           }
-          console.log("Check was not completed; marking the check run as failed; details are ", data);
+          console.log(`::group::Status was ${data.status}; marking the check run as failed.`);
+          console.log(data);
+          console.log("::endgroup::");
           await github.rest.checks.update({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",

--- a/action.yaml
+++ b/action.yaml
@@ -289,6 +289,9 @@ runs:
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
+          # The below snippet doesn't work for destructuring, weirdly enough...
+          const { data: { status } } = check;
+            console.log('try nested destructure', status);
           if (check.data.status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -292,7 +292,7 @@ runs:
           });
           if (data.status === "completed") {
             console.log("Success!");
-            return;
+            //return;
           }
           console.log("Check was not completed; marking the check run as failed; details are ", data);
           await github.rest.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -290,6 +290,8 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           console.log('check API returned', check);
+          console.log('check API data', check.data);
+          console.log('check API status', check.data.status);
           const { data: { status: checkStatus } } = check;
           console.log('returned status is', checkStatus);
           if (status === "completed") {

--- a/action.yaml
+++ b/action.yaml
@@ -283,15 +283,16 @@ runs:
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}
+        # Both destructuring forms cause "SyntaxError: Invalid or unexpected token"
         script: |
           const check = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          # The below snippet doesn't work for destructuring, weirdly enough...
           const { data: { status: checkStatus } } = check;
-          console.log("try nested destructure", checkStatus);
+          const { data: { status } } = check;
+          console.log("try nested destructure", { status, checkStatus });
           if (check.data.status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -292,7 +292,7 @@ runs:
           });
           if (data.status === "completed") {
             console.log("Success!");
-            //return;
+            return;
           }
           console.log(`::group::Status was ${data.status}; marking the check run as failed.`);
           console.log(data);


### PR DESCRIPTION
In the return value of `github.rest.checks.get()`, `status` is the HTTP response code; `data.status` is the field that's `in_progress|completed`