### PR TITLE
feat: open client_payload in trunk-action, not check-service.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -291,6 +291,7 @@ runs:
           });
           console.log('check API returned', check);
           const { status } = check;
+          console.log('returned status is', status);
           if (status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -122,6 +122,7 @@ runs:
         INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).check_run_id }}
         INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.ref_name }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
+        INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunk_path }}
         INPUT_UPLOAD_SERIES=${{ fromJSON(inputs.json).upload_series }}
         EOF
 
@@ -133,13 +134,14 @@ runs:
         GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
         GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}
         GITHUB_REF_NAME=${{ github.ref_name }}
-        INPUT_ARGUMENTS=${{ inputs.cache }}
+        INPUT_ARGUMENTS=${{ inputs.arguments }}
         INPUT_CACHE=${{ inputs.cache }}
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
         INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_LABEL=${{ inputs.label }}
+        INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
         INPUT_UPLOAD_SERIES=${{ inputs.upload_series }}
         EOF
 
@@ -151,8 +153,6 @@ runs:
     - name: Locate trunk
       shell: bash
       run: ${GITHUB_ACTION_PATH}/locate_trunk.sh
-      env:
-        INPUT_TRUNK_PATH: ${{ inputs.trunk-path }}
 
     - name: Init on-demand
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -147,6 +147,7 @@ runs:
 
         fi
       env:
+        # These are handled specially because we add-mask them.
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token || fromJSON(inputs.json).github_token }}
         INPUT_TRUNK_TOKEN: ${{ inputs.trunk-token || fromJSON(inputs.json).token }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -290,8 +290,8 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           console.log('check API returned', check);
-          const { data: { status } } = check;
-          console.log('returned status is', status);
+          const { data: { status: checkStatus } } = check;
+          console.log('returned status is', checkStatus);
           if (status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -122,7 +122,6 @@ runs:
         INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).check_run_id }}
         INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.ref_name }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
-        INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunk_path }}
         INPUT_UPLOAD_SERIES=${{ fromJSON(inputs.json).upload_series }}
         EOF
 
@@ -141,7 +140,6 @@ runs:
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
         INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_LABEL=${{ inputs.label }}
-        INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
         INPUT_UPLOAD_SERIES=${{ inputs.upload_series }}
         EOF
 
@@ -153,6 +151,8 @@ runs:
     - name: Locate trunk
       shell: bash
       run: ${GITHUB_ACTION_PATH}/locate_trunk.sh
+      env:
+        INPUT_TRUNK_PATH: ${{ inputs.trunk-path }}
 
     - name: Init on-demand
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -284,11 +284,13 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const { status } = await github.rest.checks.get({
+          const check = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
+          console.log('check API returned', check);
+          const { status } = check;
           if (status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -284,14 +284,17 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const { data: { status: checkStatus } } = await github.rest.checks.get({
+          console.log("Verifying that the GitHub check run was updated with results...");
+          const { data } = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          if (checkStatus === "completed") {
+          if (data.status === "completed") {
+            console.log("Success!");
             return;
           }
+          console.log("Check was not completed; marking the check run as failed; details are ", data);
           await github.rest.checks.update({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",

--- a/action.yaml
+++ b/action.yaml
@@ -84,6 +84,10 @@ inputs:
     required: false
     default: "false"
 
+  json:
+    description: Used by CheckService
+    required: false
+
 runs:
   using: composite
   steps:
@@ -95,20 +99,55 @@ runs:
 
         cat >>$GITHUB_ENV <<EOF
         GITHUB_TOKEN=${{ github.token }}
-        INPUT_ARGUMENTS=${{ inputs.arguments }}
-        INPUT_GITHUB_REF_NAME=${{ env.INPUT_GITHUB_REF_NAME || github.ref_name }}
-        INPUT_LABEL=${{ inputs.label }}
+        INPUT_GITHUB_TOKEN=$INPUT_GITHUB_TOKEN
         INPUT_TRUNK_TOKEN=$INPUT_TRUNK_TOKEN
         EOF
+
+        # Every inputs.field should be referenced as INPUT_FIELD later in the action. This allows
+        # the field to be set either as an argument to the github action or via inputs.json.
+        if [[ -n "${{ fromJSON(inputs.json).version }}" ]]; then
+          cat >>$GITHUB_ENV <<EOF
+          GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER=${{ fromJSON(inputs.json).pull_request.base.repo.owner.login }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME=${{ fromJSON(inputs.json).pull_request.base.repo.name }}
+          GITHUB_EVENT_PULL_REQUEST_BASE_SHA=${{ fromJSON(inputs.json).pull_request.base.sha }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK=${{ fromJSON(inputs.json).pull_request.head.repo.fork }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ fromJSON(inputs.json).pull_request.head.sha }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ fromJSON(inputs.json).pull_request.number }}
+          INPUT_ARGUMENTS=${{ fromJSON(inputs.json).arguments }}
+          INPUT_CACHE=${{ fromJSON(inputs.json).cache }}
+          INPUT_CHECK_ALL_MODE=${{ fromJSON(inputs.json).check_all_mode }}
+          INPUT_CHECK_MODE=${{ fromJSON(inputs.json).check_mode }}
+          INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).check_run_id }}
+          INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.ref_name }}
+          INPUT_LABEL=${{ fromJSON(inputs.json).label }}
+          INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunk_path }}
+          INPUT_UPLOAD_SERIES=${{ fromJSON(inputs.json).upload_series }}
+          EOF
+        else
+          cat >>$GITHUB_ENV <<EOF
+          GITHUB_EVENT_PULL_REQUEST_BASE_SHA=${{ github.event.pull_request.base.sha }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK=${{ github.event.pull_request.head.repo.fork }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}
+          GITHUB_REF_NAME=${{ github.ref_name }}
+          INPUT_ARGUMENTS=${{ inputs.cache }}
+          INPUT_CACHE=${{ inputs.cache }}
+          INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
+          INPUT_CHECK_MODE=${{ inputs.check-mode }}
+          INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
+          INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
+          INPUT_LABEL=${{ inputs.label }}
+          INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
+          INPUT_UPLOAD_SERIES=${{ inputs.upload_series }}
+          EOF
+        fi
       env:
-        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
-        INPUT_TRUNK_TOKEN: ${{ inputs.trunk-token }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token || fromJSON(inputs.json).github_token }}
+        INPUT_TRUNK_TOKEN: ${{ inputs.trunk-token || fromJSON(inputs.json).token }}
 
     - name: Locate trunk
       shell: bash
       run: ${GITHUB_ACTION_PATH}/locate_trunk.sh
-      env:
-        INPUT_TRUNK_PATH: ${{ inputs.trunk-path }}
 
     - name: Init on-demand
       shell: bash
@@ -166,11 +205,9 @@ runs:
       run: |
         # Determine check mode
         ${GITHUB_ACTION_PATH}/determine_check_mode.sh
-      env:
-        INPUT_CHECK_MODE: ${{ inputs.check-mode }}
 
     - name: Cache Linters/Formatters
-      if: env.TRUNK_CHECK_MODE != 'none' && inputs.cache == 'true'
+      if: env.TRUNK_CHECK_MODE != 'none' && env.INPUT_CACHE == 'true'
       uses: actions/cache@v3
       with:
         path: ~/.cache/trunk
@@ -183,16 +220,6 @@ runs:
         # Run 'trunk check' on pull request
         ${GITHUB_ACTION_PATH}/pull_request.sh
       env:
-        GITHUB_EVENT_PULL_REQUEST_BASE_SHA:
-          ${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_SHA || github.event.pull_request.base.sha }}
-        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK:
-          ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK ||
-          github.event.pull_request.head.repo.fork }}
-        GITHUB_EVENT_PULL_REQUEST_HEAD_SHA:
-          ${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA || github.event.pull_request.head.sha }}
-        GITHUB_EVENT_PULL_REQUEST_NUMBER:
-          ${{ env.GITHUB_EVENT_PULL_REQUEST_NUMBER || github.event.pull_request.number }}
-        INPUT_CHECK_RUN_ID: ${{ inputs.check-run-id }}
         INPUT_SAVE_ANNOTATIONS: ${{ inputs.save-annotations }}
 
     - name: Run trunk check on push
@@ -211,9 +238,6 @@ runs:
       run: |
         # Run 'trunk check' on all
         ${GITHUB_ACTION_PATH}/all.sh
-      env:
-        INPUT_CHECK_ALL_MODE: ${{ inputs.check-all-mode }}
-        INPUT_UPLOAD_SERIES: ${{ inputs.upload-series }}
 
     - name: Run trunk check on Trunk Merge
       if: env.TRUNK_CHECK_MODE == 'trunk_merge'
@@ -278,17 +302,17 @@ runs:
         GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
     - name: Finalize check run
-      if: always() && inputs.check-run-id
+      if: always() && env.INPUT_CHECK_RUN_ID
       continue-on-error: true
       uses: actions/github-script@v6
       with:
-        github-token: ${{ inputs.github-token }}
+        github-token: ${{ env.INPUT_GITHUB_TOKEN }}
         script: |
           console.log("Verifying that the GitHub check run was updated with results...");
           const { data } = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
-            check_run_id: ${{ inputs.check-run-id }}
+            check_run_id: ${{ env.INPUT_CHECK_RUN_ID }}
           });
           if (data.status === "completed") {
             console.log("Success!");
@@ -300,7 +324,7 @@ runs:
           await github.rest.checks.update({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
-            check_run_id: ${{ inputs.check-run-id }},
+            check_run_id: ${{ env.INPUT_CHECK_RUN_ID }},
             head_sha: "${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }}",
             status: "completed",
             conclusion: "failure",

--- a/action.yaml
+++ b/action.yaml
@@ -283,17 +283,13 @@ runs:
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}
-        # Both destructuring forms cause "SyntaxError: Invalid or unexpected token"
         script: |
-          const check = await github.rest.checks.get({
+          const { data: { status: checkStatus } } = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          const { data: { status: checkStatus } } = check;
-          const { data: { status } } = check;
-          console.log("try nested destructure", { status, checkStatus });
-          if (check.data.status === "completed") {
+          if (checkStatus === "completed") {
             return;
           }
           await github.rest.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -290,7 +290,7 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           console.log('check API returned', check);
-          const { status } = check;
+          const { data: { status } } = check;
           console.log('returned status is', status);
           if (status === "completed") {
             return;

--- a/action.yaml
+++ b/action.yaml
@@ -290,8 +290,8 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           # The below snippet doesn't work for destructuring, weirdly enough...
-          const { data: { status } } = check;
-            console.log('try nested destructure', status);
+          const { data: { status: checkStatus } } = check;
+          console.log("try nested destructure", checkStatus);
           if (check.data.status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -107,40 +107,44 @@ runs:
         # Every inputs.field should be referenced as INPUT_FIELD later in the action. This allows
         # the field to be set either as an argument to the github action or via inputs.json.
         if [[ -n "${{ fromJSON(inputs.json).version }}" ]]; then
+
           cat >>$GITHUB_ENV <<EOF
-          GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER=${{ fromJSON(inputs.json).pull_request.base.repo.owner.login }}
-          GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME=${{ fromJSON(inputs.json).pull_request.base.repo.name }}
-          GITHUB_EVENT_PULL_REQUEST_BASE_SHA=${{ fromJSON(inputs.json).pull_request.base.sha }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK=${{ fromJSON(inputs.json).pull_request.head.repo.fork }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ fromJSON(inputs.json).pull_request.head.sha }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ fromJSON(inputs.json).pull_request.number }}
-          INPUT_ARGUMENTS=${{ fromJSON(inputs.json).arguments }}
-          INPUT_CACHE=${{ fromJSON(inputs.json).cache }}
-          INPUT_CHECK_ALL_MODE=${{ fromJSON(inputs.json).check_all_mode }}
-          INPUT_CHECK_MODE=${{ fromJSON(inputs.json).check_mode }}
-          INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).check_run_id }}
-          INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.ref_name }}
-          INPUT_LABEL=${{ fromJSON(inputs.json).label }}
-          INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunk_path }}
-          INPUT_UPLOAD_SERIES=${{ fromJSON(inputs.json).upload_series }}
-          EOF
+        GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER=${{ fromJSON(inputs.json).pull_request.base.repo.owner.login }}
+        GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME=${{ fromJSON(inputs.json).pull_request.base.repo.name }}
+        GITHUB_EVENT_PULL_REQUEST_BASE_SHA=${{ fromJSON(inputs.json).pull_request.base.sha }}
+        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK=${{ fromJSON(inputs.json).pull_request.head.repo.fork }}
+        GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ fromJSON(inputs.json).pull_request.head.sha }}
+        GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ fromJSON(inputs.json).pull_request.number }}
+        INPUT_ARGUMENTS=${{ fromJSON(inputs.json).arguments }}
+        INPUT_CACHE=${{ fromJSON(inputs.json).cache }}
+        INPUT_CHECK_ALL_MODE=${{ fromJSON(inputs.json).check_all_mode }}
+        INPUT_CHECK_MODE=${{ fromJSON(inputs.json).check_mode }}
+        INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).check_run_id }}
+        INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.ref_name }}
+        INPUT_LABEL=${{ fromJSON(inputs.json).label }}
+        INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunk_path }}
+        INPUT_UPLOAD_SERIES=${{ fromJSON(inputs.json).upload_series }}
+        EOF
+
         else
+
           cat >>$GITHUB_ENV <<EOF
-          GITHUB_EVENT_PULL_REQUEST_BASE_SHA=${{ github.event.pull_request.base.sha }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK=${{ github.event.pull_request.head.repo.fork }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}
-          GITHUB_REF_NAME=${{ github.ref_name }}
-          INPUT_ARGUMENTS=${{ inputs.cache }}
-          INPUT_CACHE=${{ inputs.cache }}
-          INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
-          INPUT_CHECK_MODE=${{ inputs.check-mode }}
-          INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
-          INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
-          INPUT_LABEL=${{ inputs.label }}
-          INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
-          INPUT_UPLOAD_SERIES=${{ inputs.upload_series }}
-          EOF
+        GITHUB_EVENT_PULL_REQUEST_BASE_SHA=${{ github.event.pull_request.base.sha }}
+        GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK=${{ github.event.pull_request.head.repo.fork }}
+        GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+        GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}
+        GITHUB_REF_NAME=${{ github.ref_name }}
+        INPUT_ARGUMENTS=${{ inputs.cache }}
+        INPUT_CACHE=${{ inputs.cache }}
+        INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
+        INPUT_CHECK_MODE=${{ inputs.check-mode }}
+        INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
+        INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
+        INPUT_LABEL=${{ inputs.label }}
+        INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
+        INPUT_UPLOAD_SERIES=${{ inputs.upload_series }}
+        EOF
+
         fi
       env:
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token || fromJSON(inputs.json).github_token }}

--- a/action.yaml
+++ b/action.yaml
@@ -289,12 +289,7 @@ runs:
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          console.log('check API returned', check);
-          console.log('check API data', check.data);
-          console.log('check API status', check.data.status);
-          const { data: { status: checkStatus } } = check;
-          console.log('returned status is', checkStatus);
-          if (status === "completed") {
+          if (check.data.status === "completed") {
             return;
           }
           await github.rest.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -294,7 +294,9 @@ runs:
             console.log("Success!");
             //return;
           }
-          console.log("Check was not completed; marking the check run as failed; details are ", data);
+          console.log(`::group::Status was ${data.status}; marking the check run as failed.`);
+          console.log(data);
+          console.log("::endgroup::");
           await github.rest.checks.update({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",

--- a/action.yaml
+++ b/action.yaml
@@ -289,6 +289,9 @@ runs:
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
+          # The below snippet doesn't work for destructuring, weirdly enough...
+          const { data: { status } } = check;
+            console.log('try nested destructure', status);
           if (check.data.status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -292,7 +292,7 @@ runs:
           });
           if (data.status === "completed") {
             console.log("Success!");
-            return;
+            //return;
           }
           console.log("Check was not completed; marking the check run as failed; details are ", data);
           await github.rest.checks.update({

--- a/action.yaml
+++ b/action.yaml
@@ -290,6 +290,8 @@ runs:
             check_run_id: ${{ inputs.check-run-id }}
           });
           console.log('check API returned', check);
+          console.log('check API data', check.data);
+          console.log('check API status', check.data.status);
           const { data: { status: checkStatus } } = check;
           console.log('returned status is', checkStatus);
           if (status === "completed") {

--- a/action.yaml
+++ b/action.yaml
@@ -283,15 +283,16 @@ runs:
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github-token }}
+        # Both destructuring forms cause "SyntaxError: Invalid or unexpected token"
         script: |
           const check = await github.rest.checks.get({
             owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
             repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
             check_run_id: ${{ inputs.check-run-id }}
           });
-          # The below snippet doesn't work for destructuring, weirdly enough...
           const { data: { status: checkStatus } } = check;
-          console.log("try nested destructure", checkStatus);
+          const { data: { status } } = check;
+          console.log("try nested destructure", { status, checkStatus });
           if (check.data.status === "completed") {
             return;
           }

--- a/action.yaml
+++ b/action.yaml
@@ -87,6 +87,7 @@ inputs:
   json:
     description: Used by CheckService
     required: false
+    default: "{}"
 
 runs:
   using: composite

--- a/action.yaml
+++ b/action.yaml
@@ -292,7 +292,7 @@ runs:
           });
           if (data.status === "completed") {
             console.log("Success!");
-            //return;
+            return;
           }
           console.log(`::group::Status was ${data.status}; marking the check run as failed.`);
           console.log(data);


### PR DESCRIPTION
This allows us to ship changes to the CheckService->trunk-action callpath without needing to make changes to the workflow file we put in folks' `.trunk` repo.