### PR TITLE
feat: fix upstream download

### DIFF
--- a/all.sh
+++ b/all.sh
@@ -17,15 +17,24 @@ if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
     ${INPUT_ARGUMENTS}
 elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
   latest_raw_upload="$(mktemp)"
-  prev_ref=$("${TRUNK_PATH}" get-latest-raw-upload \
+  # We have to tolerate failures here: the first attempt to download the latest
+  # upload for a given repo/series will always fail, because none has yet been
+  # uploaded. However, we also don't want to silently suppress errors if they
+  # occur: the user should be able to see them without having to set INPUT_DEBUG.
+  set +e
+  prev_ref="$("${TRUNK_PATH}" get-latest-raw-upload \
     --series "${INPUT_UPLOAD_SERIES:-${GITHUB_REF_NAME}}" \
     --token "${INPUT_TRUNK_TOKEN}" \
-    "${latest_raw_upload}") || prev_ref="NOT_FOUND"
-  if [[ ${prev_ref} == "NOT_FOUND" ]]; then
-    htl_arg=""
-  else
+    "${latest_raw_upload}")"
+  get_latest_raw_upload_exit_code=$?
+  set -e
+  if [[ ${get_latest_raw_upload_exit_code} == 0 ]]; then
     htl_arg="--htl-factories-path=${latest_raw_upload}"
-    git fetch "${prev_ref}"
+    git fetch origin "${prev_ref}"
+  else
+    echo "Failed to retrieve the latest upload. This is normal if no uploads"
+    echo "have been made to this series before."
+    htl_arg=""
   fi
   "${TRUNK_PATH}" check \
     --all \


### PR DESCRIPTION
Teach the trunk-action to correctly download the upstream ref (`git fetch origin $ref` over `git fetch $ref`).

Also make it so that if `get-latest-raw-upload` fails, we show the failure, but preserve the current fail open behavior (and also document why it's important!)

Tested:

```
sam@sam-dell:2023-04-12T10:56:09-0700:~/trunk (main) [1]
$ INPUT_TRUNK_TOKEN=token INPUT_UPLOAD_SERIES=main2 TRUNK_PATH=tools/trunk INPUT_CHECK_ALL_MODE=hold-the-line INPUT_DEBUG=false ~/action/all.sh
++ 2023-04-12T10:56:17-0700 ++ INPUT_TRUNK_TOKEN=token
++ 2023-04-12T10:56:17-0700 ++ INPUT_UPLOAD_SERIES=main2
++ 2023-04-12T10:56:17-0700 ++ TRUNK_PATH=tools/trunk
++ 2023-04-12T10:56:17-0700 ++ INPUT_CHECK_ALL_MODE=hold-the-line
++ 2023-04-12T10:56:17-0700 ++ INPUT_DEBUG=false
++ 2023-04-12T10:56:17-0700 ++ /home/sam/action/all.sh
Failed to retrieve the latest upload. This is normal if no uploads
have been made to this series before.
/home/sam/action/all.sh: line 39: INPUT_ARGUMENTS: unbound variable
sam@sam-dell:2023-04-12T10:56:18-0700:~/trunk (main) [1]
$ INPUT_TRUNK_TOKEN=token INPUT_UPLOAD_SERIES=main TRUNK_PATH=tools/trunk INPUT_CHECK_ALL_MODE=hold-the-line INPUT_DEBUG=false ~/action/all.sh
++ 2023-04-12T10:56:34-0700 ++ INPUT_TRUNK_TOKEN=token
++ 2023-04-12T10:56:34-0700 ++ INPUT_UPLOAD_SERIES=main
++ 2023-04-12T10:56:34-0700 ++ TRUNK_PATH=tools/trunk
++ 2023-04-12T10:56:34-0700 ++ INPUT_CHECK_ALL_MODE=hold-the-line
++ 2023-04-12T10:56:34-0700 ++ INPUT_DEBUG=false
++ 2023-04-12T10:56:34-0700 ++ /home/sam/action/all.sh
From https://github.com/trunk-io/trunk
 * branch                55f2cb12361706fa648ae61c8be74be16d011392 -> FETCH_HEAD
/home/sam/action/all.sh: line 39: INPUT_ARGUMENTS: unbound variable
```