### PR TITLE
fix: ignore landing state upload failures

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -316,7 +316,7 @@ runs:
           });
 
     - name: Upload landing state
-      if: always()
+      if: always() && env.TRUNK_CHECK_MODE == 'pull_request'
       continue-on-error: true
       uses: actions/upload-artifact@v3
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -317,6 +317,7 @@ runs:
 
     - name: Upload landing state
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@v3
       with:
         name: landing-state.json


### PR DESCRIPTION
This caused us to hit our artifact storage limit. Customers will also probably hit this.

Ignore upload errors, also only upload for PR runs.