### PR TITLE
chore: make target fields top-level

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -126,7 +126,7 @@ runs:
         INPUT_CHECK_MODE=${{ fromJSON(inputs.json).checkMode }}
         INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).checkRunId }}
         INPUT_DEBUG=${{ fromJSON(inputs.json).debug }}
-        INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.refName }}
+        INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).targetRefName }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
         INPUT_TARGET_CHECKOUT=${{ fromJSON(inputs.json).targetCheckout }}
         INPUT_TARGET_CHECKOUT_REF=${{ fromJSON(inputs.json).targetCheckoutRef }}

--- a/action.yaml
+++ b/action.yaml
@@ -128,9 +128,8 @@ runs:
         INPUT_DEBUG=${{ fromJSON(inputs.json).debug }}
         INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).target.refName }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
-        INPUT_TARGET_CHECKOUT=${{ fromJSON(inputs.json).target.checkout }}
-        INPUT_TARGET_CHECKOUT_REF=${{ fromJSON(inputs.json).target.checkoutRef }}
-        INPUT_TARGET_NAME=${{ fromJSON(inputs.json).target.name }}
+        INPUT_TARGET_CHECKOUT=${{ fromJSON(inputs.json).targetCheckout }}
+        INPUT_TARGET_CHECKOUT_REF=${{ fromJSON(inputs.json).targetCheckoutRef }}
         INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunkPath }}
         INPUT_UPLOAD_LANDING_STATE=${{ fromJSON(inputs.json).uploadLandingState }}
         INPUT_UPLOAD_SERIES=${{ fromJSON(inputs.json).uploadSeries }}
@@ -153,7 +152,6 @@ runs:
         INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_TARGET_CHECKOUT=
         INPUT_TARGET_CHECKOUT_REF=
-        INPUT_TARGET_NAME=
         INPUT_LABEL=${{ inputs.label }}
         INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
         INPUT_UPLOAD_LANDING_STATE=false
@@ -170,7 +168,7 @@ runs:
       if: env.INPUT_TARGET_CHECKOUT
       uses: actions/checkout@v3
       with:
-        repository: ${{ env.INPUT_TARGET_NAME }}
+        repository: ${{ env.INPUT_TARGET_CHECKOUT }}
         ref: ${{ env.INPUT_TARGET_CHECKOUT_REF }}
         token: ${{ env.INPUT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
Nested fields aren't worth the frustration of destructuring them inside CheckService.