### PR TITLE
fix: do not blindly write out landing-state.json

### DIFF
--- a/all.sh
+++ b/all.sh
@@ -12,7 +12,6 @@ if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
   "${TRUNK_PATH}" check \
     --ci \
     --all \
-    --output-file .trunk/landing-state.json \
     --github-commit "${GITHUB_SHA}" \
     ${INPUT_ARGUMENTS}
 elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
@@ -46,7 +45,6 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
 else
   "${TRUNK_PATH}" check \
     --all \
-    --output-file .trunk/landing-state.json \
     --upload \
     --series "${INPUT_UPLOAD_SERIES:-${INPUT_GITHUB_REF_NAME}}" \
     --token "${INPUT_TRUNK_TOKEN}" \

--- a/pull_request.sh
+++ b/pull_request.sh
@@ -50,7 +50,6 @@ fi
 
 "${TRUNK_PATH}" check \
   --ci \
-  --output-file .trunk/landing-state.json \
   --upstream "${upstream}" \
   --github-commit "${git_commit}" \
   --github-label "${INPUT_LABEL}" \

--- a/push.sh
+++ b/push.sh
@@ -42,7 +42,6 @@ fi
 
 "${TRUNK_PATH}" check \
   --ci \
-  --output-file .trunk/landing-state.json \
   --upstream "${upstream}" \
   --github-commit "${GITHUB_EVENT_AFTER}" \
   ${INPUT_ARGUMENTS}

--- a/trunk_merge.sh
+++ b/trunk_merge.sh
@@ -23,7 +23,6 @@ echo "Detected merge queue commit, using HEAD^1 (${upstream}) as upstream and HE
 
 "${TRUNK_PATH}" check \
   --ci \
-  --output-file .trunk/landing-state.json \
   --upstream "${upstream}" \
   --github-commit "${git_commit}" \
   ${INPUT_ARGUMENTS}


### PR DESCRIPTION
--output-file is not supported in old versions of trunk.

We'll want to set this ourselves for our own dogfooding via `INPUT_ARGUMENTS=--output-file=.trunk/landing-state.json` in `.trunk/setup-ci/`.