### PR TITLE
Add `--ci` to check uploads

### DIFF
--- a/all.sh
+++ b/all.sh
@@ -8,6 +8,19 @@ if [[ ${INPUT_DEBUG} == "true" ]]; then
   set -x
 fi
 
+TRUNK_VERSION=$("${TRUNK_PATH}" --version)
+MINIMUM_CI_VERSION="1.8.2-beta.12"
+
+echo "Trunk version: ${TRUNK_VERSION}"
+
+# trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
+if [[ "$(printf "%s\n%s\n" "${MINIMUM_CI_VERSION}" "${TRUNK_VERSION}" |
+  sort --version-sort |
+  head -n 1)" == "${MINIMUM_CI_VERSION}"* ]] || [[ ${TRUNK_VERSION} == "0.0.0" ]]; then
+  CI_ARGUMENT="--ci "
+fi
+# trunk-ignore-end(shellcheck/SC2312)
+
 if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
   "${TRUNK_PATH}" check \
     --ci \
@@ -28,7 +41,7 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     git fetch origin "${prev_ref}"
   fi
   "${TRUNK_PATH}" check \
-    --ci \
+    ${CI_ARGUMENT} \
     --all \
     --upload \
     ${htl_arg} \
@@ -37,7 +50,7 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     ${INPUT_ARGUMENTS}
 else
   "${TRUNK_PATH}" check \
-    --ci \
+    ${CI_ARGUMENT} \
     --all \
     --upload \
     --series "${INPUT_UPLOAD_SERIES:-${INPUT_GITHUB_REF_NAME}}" \

--- a/all.sh
+++ b/all.sh
@@ -28,6 +28,7 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     git fetch origin "${prev_ref}"
   fi
   "${TRUNK_PATH}" check \
+    --ci \
     --all \
     --upload \
     ${htl_arg} \
@@ -36,6 +37,7 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     ${INPUT_ARGUMENTS}
 else
   "${TRUNK_PATH}" check \
+    --ci \
     --all \
     --upload \
     --series "${INPUT_UPLOAD_SERIES:-${INPUT_GITHUB_REF_NAME}}" \

--- a/all.sh
+++ b/all.sh
@@ -18,6 +18,8 @@ if [[ "$(printf "%s\n%s\n" "${MINIMUM_CI_VERSION}" "${TRUNK_VERSION}" |
   sort --version-sort |
   head -n 1)" == "${MINIMUM_CI_VERSION}"* ]] || [[ ${TRUNK_VERSION} == "0.0.0" ]]; then
   CI_ARGUMENT="--ci "
+else
+  CI_ARGUMENT=""
 fi
 # trunk-ignore-end(shellcheck/SC2312)
 

--- a/all.sh
+++ b/all.sh
@@ -21,6 +21,8 @@ if [[ "$(printf "%s\n%s\n" "${MINIMUM_CI_VERSION}" "${TRUNK_VERSION}" |
 fi
 # trunk-ignore-end(shellcheck/SC2312)
 
+echo "CI arg: ${CI_ARGUMENT}"
+
 if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
   "${TRUNK_PATH}" check \
     --ci \

--- a/all.sh
+++ b/all.sh
@@ -11,8 +11,6 @@ fi
 TRUNK_VERSION=$("${TRUNK_PATH}" --version)
 MINIMUM_CI_VERSION="1.8.2-beta.12"
 
-echo "Trunk version: ${TRUNK_VERSION}"
-
 # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
 if [[ "$(printf "%s\n%s\n" "${MINIMUM_CI_VERSION}" "${TRUNK_VERSION}" |
   sort --version-sort |
@@ -22,8 +20,6 @@ else
   CI_ARGUMENT=""
 fi
 # trunk-ignore-end(shellcheck/SC2312)
-
-echo "CI arg: ${CI_ARGUMENT}"
 
 if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
   "${TRUNK_PATH}" check \

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -10,7 +10,6 @@ runs:
       run: |
         if [ ! -e .trunk/trunk.yaml ]; then
           ${TRUNK_PATH:-trunk} init
-          ${TRUNK_PATH:-trunk} upgrade cli --bleeding-edge
         fi
 
     - name: Detect npm/yarn/pnpm & custom setup

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -10,6 +10,7 @@ runs:
       run: |
         if [ ! -e .trunk/trunk.yaml ]; then
           ${TRUNK_PATH:-trunk} init
+          ${TRUNK_PATH:-trunk} upgrade cli --bleeding-edge
         fi
 
     - name: Detect npm/yarn/pnpm & custom setup


### PR DESCRIPTION
Adds the `--ci` arg when the trunk version is greater than or equal to `1.8.2-beta.12`.  Version checking logic is copied from the [launcher](https://github.com/trunk-io/trunk/blob/main/tools/trunk#L59-L75). This is tested on the PR repo_tests [here](https://github.com/trunk-io/trunk-action/actions/runs/4834941388/), I added a `trunk upgrade cli --bleeding-edge` to the action for repos that didn't have a trunk.yaml - those repos ran check with `--ci`, and the others did not.

(written by Maverick)