### PR TITLE
Fix repo tests to error if trunk-check doesn't run

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -120,7 +120,7 @@ jobs:
           check-mode: all
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
-          inputs: "{'arguments': '--output-file=.trunk/landing-state.json'}"
+          arguments: --output-file=.trunk/landing-state.json
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -5,7 +5,6 @@ jobs:
   repo_tests:
     name: ${{ matrix.repo }} ${{ matrix.description }}
     runs-on: ubuntu-latest
-    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -42,10 +41,12 @@ jobs:
               cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
               ${TRUNK_PATH} check enable clang-tidy
 
-          - repo: pallets/flask
-            ref: 2b2a7641430bc7d40dba3c8d701636fc9b16530c
-            post-init: |
-              cp local-action/repo_tests/flask.yaml .trunk/user.yaml
+          # fails because of a malformed html file
+
+          # - repo: pallets/flask
+          #   ref: 2b2a7641430bc7d40dba3c8d701636fc9b16530c
+          #   post-init: |
+          #     cp local-action/repo_tests/flask.yaml .trunk/user.yaml
 
           - repo: postcss/postcss
             ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
@@ -65,13 +66,17 @@ jobs:
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
 
-          - repo: sheldonhull/sheldonhull.hugo
-            ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
-            description: (has trunk.yaml)
+          # fails because yarn install would update the yarn lockfile
 
-          - repo: shopify/draggable
-            ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
-            description: (uses yarn)
+          # - repo: sheldonhull/sheldonhull.hugo
+          #   ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
+          #   description: (has trunk.yaml)
+
+          # fails because webpack doesn't work with newest npm: https://github.com/webpack/webpack/issues/14532
+
+          # - repo: shopify/draggable
+          #   ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
+          #   description: (uses yarn)
 
           - repo: terraform-linters/tflint
             ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
@@ -82,12 +87,14 @@ jobs:
           - repo: trunk-io/plugins
             ref: main
 
-          - repo: vuejs/core
-            ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
-            description: (uses pnpm)
-            post-init: |
-              # svgo gets confused by JS module loading
-              ${TRUNK_PATH} check disable svgo
+          # fails because pnpm version is too new
+
+          # - repo: vuejs/core
+          #   ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
+          #   description: (uses pnpm)
+          #   post-init: |
+          #     # svgo gets confused by JS module loading
+          #     ${TRUNK_PATH} check disable svgo
 
           - repo: z-shell/wiki
             ref: 7d0ea1b14d2f163d54111655aa9aa737f3710b72
@@ -104,6 +111,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: local-action
+
+      - name: Init on-demand
+        shell: bash
+        run: |
+          cat >>$GITHUB_ENV <<EOF
+          INPUT_ARGUMENTS=$INPUT_ARGUMENTS --output-file=.trunk/landing-state.json
+          EOF
 
       - name: Run trunk-action in ${{ matrix.repo }}
         id: trunk

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -47,7 +47,7 @@ jobs:
               cp local-action/repo_tests/flask.yaml .trunk/user.yaml
 
           - repo: postcss/postcss
-            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4ed
+            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
             description: (uses pnpm)
             post-init: |
               ${TRUNK_PATH} check enable eslint

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -112,7 +112,6 @@ jobs:
           check-mode: all
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
-          inputs: "{'arguments': '--output-file=.trunk/landing-state.json'}"
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -112,6 +112,7 @@ jobs:
           check-mode: all
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
+          inputs: "{'arguments': '--output-file=.trunk/landing-state.json'}"
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -5,8 +5,9 @@ jobs:
   repo_tests:
     name: ${{ matrix.repo }} ${{ matrix.description }}
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Items in this list satisfy a few criteria:

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -112,13 +112,6 @@ jobs:
         with:
           path: local-action
 
-      - name: Init on-demand
-        shell: bash
-        run: |
-          cat >>$GITHUB_ENV <<EOF
-          INPUT_ARGUMENTS=$INPUT_ARGUMENTS --output-file=.trunk/landing-state.json
-          EOF
-
       - name: Run trunk-action in ${{ matrix.repo }}
         id: trunk
         uses: ./local-action/
@@ -127,6 +120,7 @@ jobs:
           check-mode: all
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
+          inputs: "{'arguments': '--output-file=.trunk/landing-state.json'}"
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -21,13 +21,13 @@ jobs:
           #     this workflow on PRs
           #
           - repo: highlightjs/highlight.js
-            ref: 91e1898df92a7127956a4926e5e4ce94424492b7
+            ref: 4f9cd3bffb6bc55c9e2c4252c7b733a219880151
             description: (uses npm)
             post-init: |
               cp local-action/repo_tests/highlightjs.yaml .trunk/user.yaml
 
           - repo: jbeder/yaml-cpp
-            ref: 1b50109f7bea60bd382d8ea7befce3d2bd67da5f
+            ref: 0e6e28d1a38224fc8172fae0109ea7f673c096db
             description: (compile-commands.json)
             post-init: |
               # black complains about py2 code
@@ -42,18 +42,18 @@ jobs:
               ${TRUNK_PATH} check enable clang-tidy
 
           - repo: pallets/flask
-            ref: 4ddb3f73baa5b60ed83d6bb48d0d447a0d8ab492
+            ref: 2b2a7641430bc7d40dba3c8d701636fc9b16530c
             post-init: |
               cp local-action/repo_tests/flask.yaml .trunk/user.yaml
 
           - repo: postcss/postcss
-            ref: 8834314ff334ea8321bf2c83934f276d379512cd
+            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4ed
             description: (uses pnpm)
             post-init: |
               ${TRUNK_PATH} check enable eslint
 
           - repo: replayio/devtools
-            ref: 78259d9457f4f97ad130efbb6d36dae196588487
+            ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac
             description: (has trunk.yaml)
             post-init: |
               # replay is on a very old version
@@ -61,11 +61,11 @@ jobs:
             trunk-path: node_modules/.bin/trunk
 
           - repo: sass/sass
-            ref: b78c027126a9d6a3f5648a784936223ae7c730a2
+            ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
 
           - repo: sheldonhull/sheldonhull.hugo
-            ref: f4867cf31f7f7ebe57522faa946ef5105d12f17f
+            ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
             description: (has trunk.yaml)
 
           - repo: shopify/draggable
@@ -73,7 +73,7 @@ jobs:
             description: (uses yarn)
 
           - repo: terraform-linters/tflint
-            ref: 602fa73fafa020436520a0efa6cfc151d5f4c91f
+            ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
             post-init: |
               # golangci-lint needs us to init with a newer go runtime
               ${TRUNK_PATH} check disable golangci-lint
@@ -82,14 +82,14 @@ jobs:
             ref: main
 
           - repo: vuejs/core
-            ref: a0e7dc334356e9e6ffaa547d29e55b34b9b8a04d
+            ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
             description: (uses pnpm)
             post-init: |
               # svgo gets confused by JS module loading
               ${TRUNK_PATH} check disable svgo
 
           - repo: z-shell/wiki
-            ref: 06dbdbd696892bf4eda9641c88a6b406374fbaa4
+            ref: 7d0ea1b14d2f163d54111655aa9aa737f3710b72
             description: (has trunk.yaml)
 
     steps:

--- a/repo_tests/check_for_task_failures.py
+++ b/repo_tests/check_for_task_failures.py
@@ -9,6 +9,7 @@ def main(github_env_path, repo_test_name, repo_test_description):
     landing_state = json.load(open('.trunk/landing-state.json'))
   except FileNotFoundError as e:
     print("Failed to open .trunk/landing-state.json - did `trunk check` run?")
+    sys.exit(1)
     return
 
   lint_action_count = len(landing_state.get("lintActions", []))

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -11,9 +11,6 @@ runs:
         if [ ! -e .trunk/trunk.yaml ]; then
           ${TRUNK_PATH:-trunk} init
         fi
-        cat >>$GITHUB_ENV <<EOF
-        INPUT_ARGUMENTS=$INPUT_ARGUMENTS --output-file=.trunk/landing-state.json
-        EOF
 
     - name: Detect npm/yarn/pnpm & custom setup
       id: detect

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -40,6 +40,13 @@ runs:
       if: steps.detect.outputs.package_manager
       uses: actions/setup-node@v3
 
+    - name: Add landing-state.json as output file
+      shell: bash
+      run: |
+        cat >>$GITHUB_ENV <<EOF
+        INPUT_ARGUMENTS=$INPUT_ARGUMENTS --output-file=.trunk/landing-state.json
+        EOF
+
     #- name: Cache node_modules
     #  uses: actions/cache@v3
     #  with:

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -11,6 +11,9 @@ runs:
         if [ ! -e .trunk/trunk.yaml ]; then
           ${TRUNK_PATH:-trunk} init
         fi
+        cat >>$GITHUB_ENV <<EOF
+        INPUT_ARGUMENTS=$INPUT_ARGUMENTS --output-file=.trunk/landing-state.json
+        EOF
 
     - name: Detect npm/yarn/pnpm & custom setup
       id: detect
@@ -39,13 +42,6 @@ runs:
     - name: Install Node dependencies
       if: steps.detect.outputs.package_manager
       uses: actions/setup-node@v3
-
-    - name: Add landing-state.json as output file
-      shell: bash
-      run: |
-        cat >>$GITHUB_ENV <<EOF
-        INPUT_ARGUMENTS=$INPUT_ARGUMENTS --output-file=.trunk/landing-state.json
-        EOF
 
     #- name: Cache node_modules
     #  uses: actions/cache@v3


### PR DESCRIPTION
The repo tests now return an error instead of success if landing-state.json does not exist. Additionally, the job will show as failed if any individual job fails (and it still runs all tests, rather than quitting on the first fail).

I also bumped all the refs for the repos to latest main.

However, several repos fail the test, all for different reasons, and I'm not quite sure how to handle that:
 - vuejs/core fails because pnpm version is too new
 - shopify/draggable fails because webpack doesn't work with newest npm: https://github.com/webpack/webpack/issues/14532
 - sheldonhull/sheldonhull.hugo fails because yarn install would update the yarn lockfile
 - pallets/flask fails because of a linter failure in an invalid html file

I'm PRing this now to get eyes on it, despite likely needing to fix the issues with the repos before merging.