### PR TITLE
fix: actually install node during setup

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -66,17 +66,13 @@ jobs:
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
 
-          # fails because yarn install would update the yarn lockfile
+          - repo: sheldonhull/sheldonhull.hugo
+            ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
+            description: (has trunk.yaml)
 
-          # - repo: sheldonhull/sheldonhull.hugo
-          #   ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
-          #   description: (has trunk.yaml)
-
-          # fails because webpack doesn't work with newest npm: https://github.com/webpack/webpack/issues/14532
-
-          # - repo: shopify/draggable
-          #   ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
-          #   description: (uses yarn)
+          - repo: shopify/draggable
+            ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
+            description: (uses yarn)
 
           - repo: terraform-linters/tflint
             ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
@@ -87,14 +83,12 @@ jobs:
           - repo: trunk-io/plugins
             ref: main
 
-          # fails because pnpm version is too new
-
-          # - repo: vuejs/core
-          #   ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
-          #   description: (uses pnpm)
-          #   post-init: |
-          #     # svgo gets confused by JS module loading
-          #     ${TRUNK_PATH} check disable svgo
+          - repo: vuejs/core
+            ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
+            description: (uses pnpm)
+            post-init: |
+              # svgo gets confused by JS module loading
+              ${TRUNK_PATH} check disable svgo
 
           - repo: z-shell/wiki
             ref: 7d0ea1b14d2f163d54111655aa9aa737f3710b72

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -66,9 +66,11 @@ jobs:
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
 
-          - repo: sheldonhull/sheldonhull.hugo
-            ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
-            description: (has trunk.yaml)
+          # fails because yarn install would update the yarn lockfile
+
+          # - repo: sheldonhull/sheldonhull.hugo
+          #   ref: 4796211f1adeeb1858f2f9bf74d7ee0b4e2d8988
+          #   description: (has trunk.yaml)
 
           - repo: shopify/draggable
             ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
@@ -83,12 +85,14 @@ jobs:
           - repo: trunk-io/plugins
             ref: main
 
-          - repo: vuejs/core
-            ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
-            description: (uses pnpm)
-            post-init: |
-              # svgo gets confused by JS module loading
-              ${TRUNK_PATH} check disable svgo
+          # fails because pnpm version is too new
+
+          # - repo: vuejs/core
+          #   ref: 2d9f6f926453c46f542789927bcd30d15da9c24b
+          #   description: (uses pnpm)
+          #   post-init: |
+          #     # svgo gets confused by JS module loading
+          #     ${TRUNK_PATH} check disable svgo
 
           - repo: z-shell/wiki
             ref: 7d0ea1b14d2f163d54111655aa9aa737f3710b72

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -20,14 +20,40 @@ runs:
           echo "package_manager=npm" >> $GITHUB_OUTPUT
           echo "install_cmd=npm ci" >> $GITHUB_OUTPUT
           echo "hash_glob=**/package-lock.json" >> $GITHUB_OUTPUT
+          FOUND_NODE=1
         elif [ -e yarn.lock ]; then
           echo "package_manager=yarn" >> $GITHUB_OUTPUT
           echo "install_cmd=yarn install --immutable" >> $GITHUB_OUTPUT
           echo "hash_glob=**/yarn.lock" >> $GITHUB_OUTPUT
+          FOUND_NODE=1
         elif [ -e pnpm-lock.yaml ]; then
           echo "package_manager=pnpm" >> $GITHUB_OUTPUT
           echo "install_cmd=pnpm install --frozen-lockfile" >> $GITHUB_OUTPUT
           echo "hash_glob=**/pnpm-lock.yaml" >> $GITHUB_OUTPUT
+          FOUND_NODE=1
+        fi
+
+        if [ ! -v FOUND_NODE ]; then
+          exit 0
+        fi
+
+        if [ -e .nvmrc ]; then
+          echo "node_version_file=.nvmrc" >> $GITHUB_OUTPUT
+        elif [ -e .node-version ]; then
+          echo "node_version_file=.node-version" >> $GITHUB_OUTPUT
+        elif [ -e .tool-versions ]; then
+          echo "node_version_file=.tool-versions" >> $GITHUB_OUTPUT
+        elif [ -e package.json ]; then
+          echo "node_version_file=package.json" >> $GITHUB_OUTPUT
+        fi
+
+        echo "Found node lockfiles but no node version!"
+
+        if which node; then
+          echo "Detected existing node install"
+          echo "node_version_file=" >> $GITHUB_OUTPUT
+        else
+          echo "Found node lockfiles but no node version!"
         fi
 
     - name: Install pnpm
@@ -37,10 +63,10 @@ runs:
         version: latest
 
     - name: Install Node dependencies
-      if: steps.detect.outputs.package_manager
+      if: steps.detect.outputs.package_manager && steps.detect.outputs.node_version_file
       uses: actions/setup-node@v3
       with:
-        node-version-file: package.json
+        node-version-file: ${{ steps.detect.outputs.node_version_file }}
 
     #- name: Cache node_modules
     #  uses: actions/cache@v3
@@ -49,6 +75,6 @@ runs:
     #    key: ${{ runner.os }}-node_modules-${{ hashFiles(steps.detect.outputs.hash_glob) }}
 
     - name: Install ${{ steps.detect.outputs.package_manager }} packages
-      if: steps.detect.outputs.package_manager
+      if: steps.detect.outputs.package_manager && steps.detect.outputs.node_version_file
       shell: bash
       run: ${{ steps.detect.outputs.install_cmd }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -20,38 +20,29 @@ runs:
           echo "package_manager=npm" >> $GITHUB_OUTPUT
           echo "install_cmd=npm ci" >> $GITHUB_OUTPUT
           echo "hash_glob=**/package-lock.json" >> $GITHUB_OUTPUT
-          FOUND_NODE=true
         elif [ -e yarn.lock ]; then
           echo "package_manager=yarn" >> $GITHUB_OUTPUT
           echo "install_cmd=yarn install --immutable" >> $GITHUB_OUTPUT
           echo "hash_glob=**/yarn.lock" >> $GITHUB_OUTPUT
-          FOUND_NODE=true
         elif [ -e pnpm-lock.yaml ]; then
           echo "package_manager=pnpm" >> $GITHUB_OUTPUT
           echo "install_cmd=pnpm install --frozen-lockfile" >> $GITHUB_OUTPUT
           echo "hash_glob=**/pnpm-lock.yaml" >> $GITHUB_OUTPUT
-          FOUND_NODE=true
-        fi
-
-        if [ -v $FOUND_NODE ]; then
+        else
           exit 0
         fi
 
         if [ -e .nvmrc ]; then
           echo "node_version_file=.nvmrc" >> $GITHUB_OUTPUT
-          FOUND_NODE_VERSION=1
+          exit 0
         elif [ -e .node-version ]; then
           echo "node_version_file=.node-version" >> $GITHUB_OUTPUT
-          FOUND_NODE_VERSION=1
+          exit 0
         elif [ -e .tool-versions ]; then
           echo "node_version_file=.tool-versions" >> $GITHUB_OUTPUT
-          FOUND_NODE_VERSION=1
+          exit 0
         elif [ -e package.json ]; then
           echo "node_version_file=package.json" >> $GITHUB_OUTPUT
-          FOUND_NODE_VERSION=1
-        fi
-
-        if [ -v $FOUND_NODE_VERSION ]; then
           exit 0
         fi
 

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -39,6 +39,8 @@ runs:
     - name: Install Node dependencies
       if: steps.detect.outputs.package_manager
       uses: actions/setup-node@v3
+      with:
+        node-version-file: package-lock.json
 
     #- name: Cache node_modules
     #  uses: actions/cache@v3

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -20,20 +20,20 @@ runs:
           echo "package_manager=npm" >> $GITHUB_OUTPUT
           echo "install_cmd=npm ci" >> $GITHUB_OUTPUT
           echo "hash_glob=**/package-lock.json" >> $GITHUB_OUTPUT
-          FOUND_NODE=1
+          FOUND_NODE=true
         elif [ -e yarn.lock ]; then
           echo "package_manager=yarn" >> $GITHUB_OUTPUT
           echo "install_cmd=yarn install --immutable" >> $GITHUB_OUTPUT
           echo "hash_glob=**/yarn.lock" >> $GITHUB_OUTPUT
-          FOUND_NODE=1
+          FOUND_NODE=true
         elif [ -e pnpm-lock.yaml ]; then
           echo "package_manager=pnpm" >> $GITHUB_OUTPUT
           echo "install_cmd=pnpm install --frozen-lockfile" >> $GITHUB_OUTPUT
           echo "hash_glob=**/pnpm-lock.yaml" >> $GITHUB_OUTPUT
-          FOUND_NODE=1
+          FOUND_NODE=true
         fi
 
-        if [ ! -v FOUND_NODE ]; then
+        if [ ! -v $FOUND_NODE ]; then
           exit 0
         fi
 
@@ -51,7 +51,7 @@ runs:
           FOUND_NODE_VERSION=1
         fi
 
-        if [ ! -v FOUND_NODE_VERSION ]; then
+        if [ ! -v $FOUND_NODE_VERSION ]; then
           exit 0
         fi
 

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -39,21 +39,29 @@ runs:
 
         if [ -e .nvmrc ]; then
           echo "node_version_file=.nvmrc" >> $GITHUB_OUTPUT
+          FOUND_NODE_VERSION=1
         elif [ -e .node-version ]; then
           echo "node_version_file=.node-version" >> $GITHUB_OUTPUT
+          FOUND_NODE_VERSION=1
         elif [ -e .tool-versions ]; then
           echo "node_version_file=.tool-versions" >> $GITHUB_OUTPUT
+          FOUND_NODE_VERSION=1
         elif [ -e package.json ]; then
           echo "node_version_file=package.json" >> $GITHUB_OUTPUT
+          FOUND_NODE_VERSION=1
+        fi
+
+        if [ ! -v FOUND_NODE_VERSION ]; then
+          exit 0
         fi
 
         echo "Found node lockfiles but no node version!"
 
-        if which node; then
+        if which node > /dev/null; then
           echo "Detected existing node install"
           echo "run_install_node_packages=true" >> $GITHUB_OUTPUT
         else
-          echo "Found node lockfiles but no node version!"
+          echo "Could not find existing node install, skipping node package installation"
         fi
 
     - name: Install pnpm

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -51,7 +51,7 @@ runs:
 
         if which node; then
           echo "Detected existing node install"
-          echo "node_version_file=" >> $GITHUB_OUTPUT
+          echo "run_install_node_packages=true" >> $GITHUB_OUTPUT
         else
           echo "Found node lockfiles but no node version!"
         fi
@@ -75,6 +75,8 @@ runs:
     #    key: ${{ runner.os }}-node_modules-${{ hashFiles(steps.detect.outputs.hash_glob) }}
 
     - name: Install ${{ steps.detect.outputs.package_manager }} packages
-      if: steps.detect.outputs.package_manager && steps.detect.outputs.node_version_file
+      if:
+        steps.detect.outputs.package_manager && (steps.detect.outputs.node_version_file ||
+        steps.detect.outputs.run_install_node_packages)
       shell: bash
       run: ${{ steps.detect.outputs.install_cmd }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -33,7 +33,7 @@ runs:
           FOUND_NODE=true
         fi
 
-        if [ ! -v $FOUND_NODE ]; then
+        if [ -v $FOUND_NODE ]; then
           exit 0
         fi
 
@@ -51,7 +51,7 @@ runs:
           FOUND_NODE_VERSION=1
         fi
 
-        if [ ! -v $FOUND_NODE_VERSION ]; then
+        if [ -v $FOUND_NODE_VERSION ]; then
           exit 0
         fi
 

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -46,7 +46,7 @@ runs:
           exit 0
         fi
 
-        echo "Found node lockfiles but no node version!"
+        echo "Found node lockfiles but no node version to install"
 
         if which node > /dev/null; then
           echo "Detected existing node install"

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -40,7 +40,7 @@ runs:
       if: steps.detect.outputs.package_manager
       uses: actions/setup-node@v3
       with:
-        node-version-file: package-lock.json
+        node-version-file: package.json
 
     #- name: Cache node_modules
     #  uses: actions/cache@v3


### PR DESCRIPTION
We have never passed a node version into the setup-node action, making that action a no-op. This worked previously because the github `ubuntu-latest` runners have node installed by default. However, after switching over to our self-hosted runners that do not have node installed, the action started failing.

This PR adds logic to detect files that have the node version, and pass them into the setup_node action to be parsed. It also adds shopify/draggable back to the repo_tests, as it was failing because the node version was too new.