### PR TITLE
fix: cache linters/formatters correctly

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -119,7 +119,7 @@ jobs:
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
           arguments: --output-file=.trunk/landing-state.json
-          cache-key: ${{ matrix.repo }}
+          cache-key: repo_tests/${{ matrix.repo }}
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -119,8 +119,7 @@ jobs:
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
           arguments: --output-file=.trunk/landing-state.json
-          cache-key: ${{ format('{0}/{1}', matrix.repo, matrix.ref) }}
-          restore-cache-key: ${{ matrix.repo }}
+          cache-key: ${{ matrix.repo }}
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -119,6 +119,8 @@ jobs:
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
           arguments: --output-file=.trunk/landing-state.json
+          cache-key: ${{ format('{0}/{1}', matrix.repo, matrix.ref) }}
+          restore-cache-key: ${{ matrix.repo }}
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -114,7 +114,7 @@ jobs:
         id: trunk
         uses: ./local-action/
         with:
-          cache: false
+          cache: true
           check-mode: all
           trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}

--- a/action.yaml
+++ b/action.yaml
@@ -122,6 +122,8 @@ runs:
         GITHUB_EVENT_PULL_REQUEST_NUMBER=${{ fromJSON(inputs.json).pullRequest.number }}
         INPUT_ARGUMENTS=${{ fromJSON(inputs.json).arguments }}
         INPUT_CACHE=${{ fromJSON(inputs.json).cache }}
+        INPUT_CACHE_KEY=${{ fromJSON(inputs.json).cacheKey }}
+        INPUT_RESTORE_CACHE_KEY=${{ fromJSON(inputs.json).restoreCacheKey }}
         INPUT_CHECK_ALL_MODE=${{ fromJSON(inputs.json).checkAllMode }}
         INPUT_CHECK_MODE=${{ fromJSON(inputs.json).checkMode }}
         INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).checkRunId }}
@@ -145,6 +147,8 @@ runs:
         GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_ARGUMENTS=${{ inputs.arguments }}
         INPUT_CACHE=${{ inputs.cache }}
+        INPUT_CACHE_KEY=`echo '${{ github.repository }}/${{ github.event.pull_request.head.ref }}' | sed s,/,-,g`
+        INPUT_RESTORE_CACHE_KEY=`echo '${{ github.repository }}' | sed s,/,-,g`
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
@@ -205,7 +209,9 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/trunk
-        key: trunk-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
+        key: trunk-${{ env.INPUT_CACHE_KEY }}-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
+        restore-keys: |
+          trunk-${{ env.INPUT_RESTORE_CACHE_KEY }}
 
     - name: Run trunk check on pull request
       if: env.TRUNK_CHECK_MODE == 'pull_request'

--- a/action.yaml
+++ b/action.yaml
@@ -147,8 +147,8 @@ runs:
         GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_ARGUMENTS=${{ inputs.arguments }}
         INPUT_CACHE=${{ inputs.cache }}
-        INPUT_CACHE_KEY=$(echo '${{ github.repository }}/${{ github.event.pull_request.head.ref }}' | sed s,/,-,g)
-        INPUT_RESTORE_CACHE_KEY=$(echo '${{ github.repository }}' | sed s,/,-,g)
+        INPUT_CACHE_KEY=${{ inputs.cache-key }}
+        INPUT_RESTORE_CACHE_KEY=${{ inputs.restore-cache-key }}
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}

--- a/action.yaml
+++ b/action.yaml
@@ -53,10 +53,6 @@ inputs:
       A key unique to the repo/branch this action is being run on (e.g. the repo name and branch)
     required: false
 
-  restore-cache-key:
-    description: A key unique to the repo this action is being run on (e.g. the repo name)
-    required: false
-
   post-init:
     description: Steps to run after auto-init / before check
     required: false
@@ -132,7 +128,6 @@ runs:
         INPUT_ARGUMENTS=${{ fromJSON(inputs.json).arguments }}
         INPUT_CACHE=${{ fromJSON(inputs.json).cache }}
         INPUT_CACHE_KEY=${{ fromJSON(inputs.json).cacheKey }}
-        INPUT_RESTORE_CACHE_KEY=${{ fromJSON(inputs.json).restoreCacheKey }}
         INPUT_CHECK_ALL_MODE=${{ fromJSON(inputs.json).checkAllMode }}
         INPUT_CHECK_MODE=${{ fromJSON(inputs.json).checkMode }}
         INPUT_CHECK_RUN_ID=${{ fromJSON(inputs.json).checkRunId }}
@@ -157,7 +152,6 @@ runs:
         INPUT_ARGUMENTS=${{ inputs.arguments }}
         INPUT_CACHE=${{ inputs.cache }}
         INPUT_CACHE_KEY=${{ inputs.cache-key }}
-        INPUT_RESTORE_CACHE_KEY=${{ inputs.restore-cache-key }}
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
@@ -203,7 +197,6 @@ runs:
       uses: ./.trunk/setup-ci
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}
-        restore-cache-key: ${{ env.INPUT_RESTORE_CACHE_KEY }}
 
     - name: Post-init steps
       if: inputs.post-init
@@ -222,8 +215,6 @@ runs:
       with:
         path: ~/.cache/trunk
         key: trunk-${{ env.INPUT_CACHE_KEY }}-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
-        restore-keys: |
-          trunk-${{ env.INPUT_RESTORE_CACHE_KEY }}
 
     - name: Run trunk check on pull request
       if: env.TRUNK_CHECK_MODE == 'pull_request'

--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,15 @@ inputs:
     required: false
     default: "true"
 
+  cache-key:
+    description:
+      A key unique to the repo/branch this action is being run on (e.g. the repo name and branch)
+    required: false
+
+  restore-cache-key:
+    description: A key unique to the repo this action is being run on (e.g. the repo name)
+    required: false
+
   post-init:
     description: Steps to run after auto-init / before check
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -201,6 +201,9 @@ runs:
 
     - name: Set up env
       uses: ./.trunk/setup-ci
+      with:
+        cache-key: ${{ env.INPUT_CACHE_KEY }}
+        restore-cache-key: ${{ env.INPUT_RESTORE_CACHE_KEY }}
 
     - name: Post-init steps
       if: inputs.post-init

--- a/action.yaml
+++ b/action.yaml
@@ -147,8 +147,8 @@ runs:
         GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_ARGUMENTS=${{ inputs.arguments }}
         INPUT_CACHE=${{ inputs.cache }}
-        INPUT_CACHE_KEY=`echo '${{ github.repository }}/${{ github.event.pull_request.head.ref }}' | sed s,/,-,g`
-        INPUT_RESTORE_CACHE_KEY=`echo '${{ github.repository }}' | sed s,/,-,g`
+        INPUT_CACHE_KEY=$(echo '${{ github.repository }}/${{ github.event.pull_request.head.ref }}' | sed s,/,-,g)
+        INPUT_RESTORE_CACHE_KEY=$(echo '${{ github.repository }}' | sed s,/,-,g)
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -83,11 +83,15 @@ runs:
       with:
         node-version-file: ${{ env.NODE_VERSION_FILE }}
 
-    #- name: Cache node_modules
-    #  uses: actions/cache@v3
-    #  with:
-    #    path: node_modules/
-    #    key: ${{ runner.os }}-node_modules-${{ hashFiles(steps.detect.outputs.hash_glob) }}
+    - name: Cache node_modules
+      uses: actions/cache@v3
+      with:
+        path: node_modules/
+        key:
+          ${{ runner.os }}-node_modules-${{ inputs.cache-key }}-${{
+          hashFiles(steps.detect.outputs.hash_glob) }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-${{ inputs.restore-cache-key }}
 
     - name: Install ${{ env.PACKAGE_MANAGER }} packages
       if: env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE || env.RUN_INSTALL_NODE_PACKAGES)

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -87,11 +87,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: node_modules/
-        key:
-          ${{ runner.os }}-node_modules-${{ inputs.cache-key }}-${{
-          hashFiles(steps.detect.outputs.hash_glob) }}
-        restore-keys: |
-          ${{ runner.os }}-node_modules-${{ inputs.restore-cache-key }}
+        key: ${{ runner.os }}-node_modules-${{ inputs.cache-key }}-${{ hashFiles(env.HASH_GLOB) }}
 
     - name: Install ${{ env.PACKAGE_MANAGER }} packages
       if: env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE || env.RUN_INSTALL_NODE_PACKAGES)

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -2,6 +2,12 @@ name: Setup environment
 author: trunk.io
 description: Automatic setup for trunk check and dependencies (e.g. Node)
 
+inputs:
+  cache-key:
+    description:
+      A key unique to the repo/branch this action is being run on (e.g. the repo name and branch)
+    required: false
+
 runs:
   using: composite
   steps:

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -84,6 +84,7 @@ runs:
         node-version-file: ${{ env.NODE_VERSION_FILE }}
 
     - name: Cache node_modules
+      if: env.PACKAGE_MANAGER
       uses: actions/cache@v3
       with:
         path: node_modules/


### PR DESCRIPTION
Because all of the caching is done in the .trunk repo, the caches for different repos in the same org stomp on each other. This introduces different keys for different repos. This can be seen in the [repo_tests running on this PR](https://github.com/trunk-io/trunk-action/actions/runs/4887481583/jobs/8724116197?pr=93). 

Additionally, this PR adds caching for the `node_modules` folder, following the same caching logic.

This has an associated PR in trunk-io/trunk, [#8408](https://github.com/trunk-io/trunk/pull/8408).