### PR TITLE
Feat: cache node modules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -201,6 +201,9 @@ runs:
 
     - name: Set up env
       uses: ./.trunk/setup-ci
+      with:
+        cache-key: ${{ env.INPUT_CACHE_KEY }}
+        restore-cache-key: ${{ env.INPUT_RESTORE_CACHE_KEY }}
 
     - name: Post-init steps
       if: inputs.post-init

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -40,11 +40,15 @@ runs:
       if: steps.detect.outputs.package_manager
       uses: actions/setup-node@v3
 
-    #- name: Cache node_modules
-    #  uses: actions/cache@v3
-    #  with:
-    #    path: node_modules/
-    #    key: ${{ runner.os }}-node_modules-${{ hashFiles(steps.detect.outputs.hash_glob) }}
+    - name: Cache node_modules
+      uses: actions/cache@v3
+      with:
+        path: node_modules/
+        key:
+          ${{ runner.os }}-node_modules-${{ inputs.cache-key }}-${{
+          hashFiles(steps.detect.outputs.hash_glob) }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-${{ inputs.restore-cache-key }}
 
     - name: Install ${{ steps.detect.outputs.package_manager }} packages
       if: steps.detect.outputs.package_manager


### PR DESCRIPTION
Following the same logic as in #93, this PR adds caching first by repo and branch, then just by repo. This can be seen [here](https://github.com/trunk-io/trunk-action/actions/runs/4824047000/jobs/8593330977).

This PR depends on #93 and [trunk-io/trunk#8408](https://github.com/trunk-io/trunk/pull/8408).

