### PR TITLE
feat: finalize via CheckService instead of the GH API

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -307,6 +307,7 @@ runs:
     - name: Finalize check run
       if: always() && env.INPUT_CHECK_RUN_ID
       continue-on-error: true
+      shell: bash
       run: |
         "${TRUNK_PATH}" check finalize-github-check-run \
           --target "${INPUT_TARGET_CHECKOUT}" \

--- a/action.yaml
+++ b/action.yaml
@@ -307,36 +307,11 @@ runs:
     - name: Finalize check run
       if: always() && env.INPUT_CHECK_RUN_ID
       continue-on-error: true
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ env.INPUT_GITHUB_TOKEN }}
-        script: |
-          console.log("Verifying that the GitHub check run was updated with results...");
-          const { data } = await github.rest.checks.get({
-            owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
-            repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
-            check_run_id: ${{ env.INPUT_CHECK_RUN_ID }}
-          });
-          if (data.status === "completed") {
-            console.log("Success!");
-            return;
-          }
-          console.log(`::group::Status was ${data.status}; marking the check run as failed.`);
-          console.log(data);
-          console.log("::endgroup::");
-          await github.rest.checks.update({
-            owner: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_OWNER }}",
-            repo: "${{ env.GITHUB_EVENT_PULL_REQUEST_BASE_REPO_NAME }}",
-            check_run_id: ${{ env.INPUT_CHECK_RUN_ID }},
-            head_sha: "${{ env.GITHUB_EVENT_PULL_REQUEST_HEAD_SHA }}",
-            status: "completed",
-            conclusion: "failure",
-            output: {
-              title: "Trunk Check",
-              summary: "unexpected failure",
-              text: "Please contact us at https://slack.trunk.io to get help",
-            },
-          });
+      run: |
+        "${TRUNK_PATH}" check finalize-github-check-run \
+          --target "${INPUT_TARGET_CHECKOUT}" \
+          --check_run_id "${INPUT_CHECK_RUN_ID}" \
+          --token "${INPUT_TRUNK_TOKEN}"
 
     - name: Upload landing state
       if: env.INPUT_UPLOAD_LANDING_STATE


### PR DESCRIPTION
Going via CheckService allows us to no longer have to worry about the GH token expiring too soon; in exchange, we have to accept that there are CLI->CheckService gaps we may not have coverage for.

This will, however, ensure coverage of the case where something in normal "trunk check" goes wrong, which is the primary case that we're concerned about.