### PR TITLE
fix: make node setup opt-in

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -120,6 +120,7 @@ jobs:
           post-init: ${{ matrix.post-init }}
           arguments: --output-file=.trunk/landing-state.json
           cache-key: repo_tests/${{ matrix.repo }}
+          setup-deps: true
         continue-on-error: true
 
       - name: Check for task failures

--- a/action.yaml
+++ b/action.yaml
@@ -206,7 +206,7 @@ runs:
 
     - name: Set up env
       uses: ./.trunk/setup-ci
-      if: env.INPUT_SETUP_DEPS == true
+      if: env.INPUT_SETUP_DEPS == 'true'
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -206,7 +206,7 @@ runs:
       uses: ./.trunk/setup-ci
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}
-        setup-deps: ${{ env.INPUT_SETUP_DEPS == 'true' }}
+        setup-deps: ${{ env.INPUT_SETUP_DEPS }}
 
     - name: Post-init steps
       if: inputs.post-init

--- a/action.yaml
+++ b/action.yaml
@@ -142,7 +142,7 @@ runs:
         INPUT_DEBUG=${{ fromJSON(inputs.json).debug }}
         INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).targetRefName }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
-        INPUT_SETUP_ENV=${{ fromJSON(inputs,json).setupEnv }}
+        INPUT_SETUP_ENV=${{ fromJSON(inputs.json).setupEnv }}
         INPUT_TARGET_CHECKOUT=${{ fromJSON(inputs.json).targetCheckout }}
         INPUT_TARGET_CHECKOUT_REF=${{ fromJSON(inputs.json).targetCheckoutRef }}
         INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunkPath }}

--- a/action.yaml
+++ b/action.yaml
@@ -196,7 +196,9 @@ runs:
     - name: Detect setup strategy
       shell: bash
       run: |
-        if [ ! -e .trunk/setup-ci ]; then
+        if [ -e .trunk/setup-ci ]; then
+          echo "INPUT_SETUP_DEPS=true" >>$GITHUB_ENV
+        else
           mkdir -p .trunk
           ln -s ${{ github.action_path }}/setup-env .trunk/setup-ci
           echo .trunk/setup-ci >>.git/info/exclude
@@ -204,9 +206,16 @@ runs:
 
     - name: Set up env
       uses: ./.trunk/setup-ci
+      if: env.INPUT_SETUP_DEPS == true
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}
-        setup-deps: ${{ env.INPUT_SETUP_DEPS }}
+
+    - name: Init on-demand
+      shell: bash
+      run: |
+        if [ ! -e .trunk/trunk.yaml ]; then
+          ${TRUNK_PATH:-trunk} init
+        fi
 
     - name: Post-init steps
       if: inputs.post-init

--- a/action.yaml
+++ b/action.yaml
@@ -89,7 +89,7 @@ inputs:
     required: false
     default: "false"
 
-  setup-env:
+  setup-deps:
     description:
       Install dependencies for trunk check that the trunk CLI does not manage. This is only
       necessary if you have Node dependencies in your package.json that your Node linters need (e.g.
@@ -142,7 +142,7 @@ runs:
         INPUT_DEBUG=${{ fromJSON(inputs.json).debug }}
         INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).targetRefName }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
-        INPUT_SETUP_ENV=${{ fromJSON(inputs.json).setupEnv }}
+        INPUT_SETUP_DEPS=${{ fromJSON(inputs.json).setupDeps }}
         INPUT_TARGET_CHECKOUT=${{ fromJSON(inputs.json).targetCheckout }}
         INPUT_TARGET_CHECKOUT_REF=${{ fromJSON(inputs.json).targetCheckoutRef }}
         INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunkPath }}
@@ -166,7 +166,7 @@ runs:
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
         INPUT_DEBUG=${{ inputs.debug }}
         INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
-        INPUT_SETUP_ENV=${{ inputs.setup-env }}
+        INPUT_SETUP_DEPS=${{ inputs.setup-deps }}
         INPUT_TARGET_CHECKOUT=
         INPUT_TARGET_CHECKOUT_REF=
         INPUT_LABEL=${{ inputs.label }}
@@ -196,20 +196,17 @@ runs:
     - name: Detect setup strategy
       shell: bash
       run: |
-        if [ -e .trunk/setup-ci ]; then
-          echo INPUT_SETUP_CI=true >>$GITHUB_ENV
-        elif [ ${INPUT_SETUP_ENV} == true ]; then
+        if [ ! -e .trunk/setup-ci ]; then
           mkdir -p .trunk
           ln -s ${{ github.action_path }}/setup-env .trunk/setup-ci
           echo .trunk/setup-ci >>.git/info/exclude
-          echo INPUT_SETUP_CI=true >>$GITHUB_ENV
         fi
 
     - name: Set up env
-      if: env.INPUT_SETUP_CI == 'true'
       uses: ./.trunk/setup-ci
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}
+        setup-deps: ${{ env.INPUT_SETUP_DEPS }}
 
     - name: Post-init steps
       if: inputs.post-init

--- a/action.yaml
+++ b/action.yaml
@@ -206,7 +206,7 @@ runs:
       uses: ./.trunk/setup-ci
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}
-        setup-deps: ${{ env.INPUT_SETUP_DEPS }}
+        setup-deps: ${{ env.INPUT_SETUP_DEPS == 'true' }}
 
     - name: Post-init steps
       if: inputs.post-init

--- a/action.yaml
+++ b/action.yaml
@@ -89,6 +89,14 @@ inputs:
     required: false
     default: "false"
 
+  setup-env:
+    description:
+      Install dependencies for trunk check that the trunk CLI does not manage. This is only
+      necessary if you have Node dependencies in your package.json that your Node linters need (e.g.
+      eslint dependencies, or @types packages).
+    required: false
+    default: false
+
   json:
     description: Used by CheckService
     required: false
@@ -134,6 +142,7 @@ runs:
         INPUT_DEBUG=${{ fromJSON(inputs.json).debug }}
         INPUT_GITHUB_REF_NAME=${{ fromJSON(inputs.json).targetRefName }}
         INPUT_LABEL=${{ fromJSON(inputs.json).label }}
+        INPUT_SETUP_ENV=${{ fromJSON(inputs,json).setupEnv }}
         INPUT_TARGET_CHECKOUT=${{ fromJSON(inputs.json).targetCheckout }}
         INPUT_TARGET_CHECKOUT_REF=${{ fromJSON(inputs.json).targetCheckoutRef }}
         INPUT_TRUNK_PATH=${{ fromJSON(inputs.json).trunkPath }}
@@ -157,6 +166,7 @@ runs:
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
         INPUT_DEBUG=${{ inputs.debug }}
         INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
+        INPUT_SETUP_ENV=${{ inputs.setup-env }}
         INPUT_TARGET_CHECKOUT=
         INPUT_TARGET_CHECKOUT_REF=
         INPUT_LABEL=${{ inputs.label }}
@@ -183,17 +193,20 @@ runs:
       shell: bash
       run: ${GITHUB_ACTION_PATH}/locate_trunk.sh
 
-    - name: Detect
-      id: detect
+    - name: Detect setup strategy
       shell: bash
       run: |
-        if [ ! -e .trunk/setup-ci ]; then
+        if [ -e .trunk/setup-ci ]; then
+          echo INPUT_SETUP_CI=true >>$GITHUB_ENV
+        elif [ ${INPUT_SETUP_ENV} == true ]; then
           mkdir -p .trunk
           ln -s ${{ github.action_path }}/setup-env .trunk/setup-ci
           echo .trunk/setup-ci >>.git/info/exclude
+          echo INPUT_SETUP_CI=true >>$GITHUB_ENV
         fi
 
     - name: Set up env
+      if: env.INPUT_SETUP_CI == 'true'
       uses: ./.trunk/setup-ci
       with:
         cache-key: ${{ env.INPUT_CACHE_KEY }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -7,6 +7,13 @@ inputs:
     description:
       A key unique to the repo/branch this action is being run on (e.g. the repo name and branch)
     required: false
+  setup-deps:
+    description:
+      Install dependencies for trunk check that the trunk CLI does not manage. This is only
+      necessary if you have Node dependencies in your package.json that your Node linters need (e.g.
+      eslint dependencies, or @types packages).
+    required: false
+    default: false
 
 runs:
   using: composite
@@ -19,8 +26,8 @@ runs:
         fi
 
     - name: Detect npm/yarn/pnpm & custom setup
-      id: detect
       shell: bash
+      if: inputs.setup-deps
       run: |
         if [ -e package-lock.json ]; then
           cat >>$GITHUB_ENV <<EOF
@@ -78,25 +85,27 @@ runs:
         fi
 
     - name: Install pnpm
-      if: env.PACKAGE_MANAGER == 'pnpm'
+      if: inputs.setup-deps && env.PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@v2
       with:
         version: latest
 
     - name: Install Node dependencies
-      if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
+      if: inputs.setup-deps && env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       uses: actions/setup-node@v3
       with:
         node-version-file: ${{ env.NODE_VERSION_FILE }}
 
     - name: Cache node_modules
-      if: env.PACKAGE_MANAGER
+      if: inputs.setup-deps && env.PACKAGE_MANAGER
       uses: actions/cache@v3
       with:
         path: node_modules/
         key: ${{ runner.os }}-node_modules-${{ inputs.cache-key }}-${{ hashFiles(env.HASH_GLOB) }}
 
     - name: Install ${{ env.PACKAGE_MANAGER }} packages
-      if: env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE || env.RUN_INSTALL_NODE_PACKAGES)
+      if:
+        inputs.setup-deps && env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE ||
+        env.RUN_INSTALL_NODE_PACKAGES)
       shell: bash
       run: ${{ env.INSTALL_CMD }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -1,33 +1,18 @@
 name: Setup environment
 author: trunk.io
-description: Automatic setup for trunk check and dependencies (e.g. Node)
+description: Automatic setup for trunk check dependencies (e.g. Node)
 
 inputs:
   cache-key:
     description:
       A key unique to the repo/branch this action is being run on (e.g. the repo name and branch)
     required: false
-  setup-deps:
-    description:
-      Install dependencies for trunk check that the trunk CLI does not manage. This is only
-      necessary if you have Node dependencies in your package.json that your Node linters need (e.g.
-      eslint dependencies, or @types packages).
-    required: false
-    default: false
 
 runs:
   using: composite
   steps:
-    - name: Init on-demand
-      shell: bash
-      run: |
-        if [ ! -e .trunk/trunk.yaml ]; then
-          ${TRUNK_PATH:-trunk} init
-        fi
-
     - name: Detect npm/yarn/pnpm & custom setup
       shell: bash
-      if: inputs.setup-deps == 'true'
       run: |
         if [ -e package-lock.json ]; then
           cat >>$GITHUB_ENV <<EOF
@@ -85,27 +70,25 @@ runs:
         fi
 
     - name: Install pnpm
-      if: inputs.setup-deps == 'true' && env.PACKAGE_MANAGER == 'pnpm'
+      if: env.PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@v2
       with:
         version: latest
 
     - name: Install Node dependencies
-      if: inputs.setup-deps == 'true' && env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
+      if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       uses: actions/setup-node@v3
       with:
         node-version-file: ${{ env.NODE_VERSION_FILE }}
 
     - name: Cache node_modules
-      if: inputs.setup-deps == 'true' && env.PACKAGE_MANAGER
+      if: env.PACKAGE_MANAGER
       uses: actions/cache@v3
       with:
         path: node_modules/
         key: ${{ runner.os }}-node_modules-${{ inputs.cache-key }}-${{ hashFiles(env.HASH_GLOB) }}
 
     - name: Install ${{ env.PACKAGE_MANAGER }} packages
-      if:
-        inputs.setup-deps == 'true' && env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE ||
-        env.RUN_INSTALL_NODE_PACKAGES)
+      if: env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE || env.RUN_INSTALL_NODE_PACKAGES)
       shell: bash
       run: ${{ env.INSTALL_CMD }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -27,7 +27,7 @@ runs:
 
     - name: Detect npm/yarn/pnpm & custom setup
       shell: bash
-      if: inputs.setup-deps
+      if: inputs.setup-deps == 'true'
       run: |
         if [ -e package-lock.json ]; then
           cat >>$GITHUB_ENV <<EOF
@@ -85,19 +85,19 @@ runs:
         fi
 
     - name: Install pnpm
-      if: inputs.setup-deps && env.PACKAGE_MANAGER == 'pnpm'
+      if: inputs.setup-deps == 'true' && env.PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@v2
       with:
         version: latest
 
     - name: Install Node dependencies
-      if: inputs.setup-deps && env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
+      if: inputs.setup-deps == 'true' && env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       uses: actions/setup-node@v3
       with:
         node-version-file: ${{ env.NODE_VERSION_FILE }}
 
     - name: Cache node_modules
-      if: inputs.setup-deps && env.PACKAGE_MANAGER
+      if: inputs.setup-deps == 'true' && env.PACKAGE_MANAGER
       uses: actions/cache@v3
       with:
         path: node_modules/
@@ -105,7 +105,7 @@ runs:
 
     - name: Install ${{ env.PACKAGE_MANAGER }} packages
       if:
-        inputs.setup-deps && env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE ||
+        inputs.setup-deps == 'true' && env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE ||
         env.RUN_INSTALL_NODE_PACKAGES)
       shell: bash
       run: ${{ env.INSTALL_CMD }}


### PR DESCRIPTION
Teaching auto-init to also install Node deps was, besides being a potentially surprising change, also broke users who configure allowlists for the set of actions that may be run in their repositories. We fix this as follows:

* move the automatic `trunk init` from the setup-env sub-action to the top-level action
* run setup-env if `inputs.setup-env` is `true` or if the CheckService call sets it to true
  * i.e. skip setup-env by default, but run it in all other scenarios
* if `.trunk/setup-ci/` exists, run that instead (regardless of the value of `inputs.setup-env`)

We have to pull the `trunk init` up a level because the actions allowlist setting enforcement is actually split between compile time and runtime:

* when the actions runner runs a composite action, it downloads the `uses` for every step in said composite action _before_ running any steps
  * see [these logs](https://github.com/trunk-io/trunk-action/actions/runs/5062175416/jobs/9087358117?pr=105) for example - notice that actions/github-script in "Trunk Check" is downloaded before the action actually runs
* but it does not do this download _recursively_
* so when the actions runner starts executing trunk-io/trunk-action, it does _not_ immediately attempt to download pnpm/action-setup
* but if/when the actions runner starts executing trunk-io/trunk-action/setup-env, it immediately attempts to download pnpm/action-setup

So to make trunk-io/trunk-action compatible with actions allowlists that only allow trunk-io/trunk-action, we must completely skip the composite action that runs pnpm/action-setup. This can be done either by skipping setup-env, or introducing another layer of composite actions between setup-env and pnpm/action-setup; this PR takes the former approach.

However, we still want auto-init to work out-of-the-box, so we pull that out of setup-env and just run that directly in the top-level action. We also choose to run it _after_ setup-env, because in theory, `trunk init` can actually need Node dependencies to be pre-installed (e.g. user lists a prettier plugin in their package.json, so when `trunk init` attempts to format `trunk.yaml` with `prettier`, `prettier` would fail because said prettier plugin must be preinstalled).

Manual tests verifying that this fix works:

* prawn-test-staging-rw/check-web is currently configured with an actions allowlist for `actions/*,trunk-io/*`
* trunk-io/trunk-action succeeds out of the box: prawn-test-staging-rw/check-web#19180
* trunk-io/trunk-action fails when `setup-deps: true`: prawn-test-staging-rw/check-web#19171

Lastly, remove IDs of workflow steps that are no longer referenced.