### PR TITLE
feat: support for PR title prefix in upgrade action

### DIFF
--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -101,13 +101,13 @@ runs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:
-        title: ${{ inputs.prefix }} ${{ env.PR_TITLE }}
+        title: ${{ inputs.prefix }}${{ env.PR_TITLE }}
         body: ${{ env.PR_DESCRIPTION }}
         base: ${{ inputs.base }}
         branch: trunk-io/update-trunk
         labels: trunk
         add-paths: .trunk
-        commit-message: ${{ inputs.prefix }} ${{ env.PR_TITLE }}
+        commit-message: ${{ inputs.prefix }}${{ env.PR_TITLE }}
         delete-branch: true
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}

--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -14,6 +14,10 @@ inputs:
       demand.
     required: false
 
+  prefix:
+    description: Prefix to be added in the PR title
+    required: false
+
   arguments:
     description: Extra arguments to pass to trunk upgrade
     required: false
@@ -97,14 +101,13 @@ runs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:
-        title: |
-          ${{ env.PR_TITLE }}
+        title: ${{ inputs.prefix }} ${{ env.PR_TITLE }}
         body: ${{ env.PR_DESCRIPTION }}
         base: ${{ inputs.base }}
         branch: trunk-io/update-trunk
         labels: trunk
         add-paths: .trunk
-        commit-message: ${{ env.PR_TITLE }}
+        commit-message: ${{ inputs.prefix }} ${{ env.PR_TITLE }}
         delete-branch: true
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}


### PR DESCRIPTION
Add support for adding **optional** prefixes in PR title.

Can be useful in a repo that utilizes conventional commits.

#### Sample Usage:
```yml
name: trunk
on:
  workflow_dispatch:

permissions: read-all

jobs:
  upgrade:
    name: upgrade trunk
    runs-on: ubuntu-latest
    permissions:
      contents: write
      pull-requests: write
    steps:
      - name: Checkout
        uses: actions/checkout@v3

      - name: Trunk Upgrade
        uses: trunk-io/trunk-action/upgrade@main
        with:
          prefix: "deps:"
```
