### PR TITLE
fix: accept clientPayload.token or clientPayload.trunkToken

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,7 @@ runs:
         if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
-          client_payload = json.loads(inputs_dict["clientPayload"])
+          client_payload = json.loads(inputs_dict["payload"])
           githubToken = client_payload["githubToken"]
           trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
         else:

--- a/action.yaml
+++ b/action.yaml
@@ -97,11 +97,6 @@ inputs:
     required: false
     default: "false"
 
-  github-event-path:
-    description: Used by CheckService
-    required: false
-    default: ""
-
   json:
     description: Used by CheckService
     required: false
@@ -126,8 +121,8 @@ runs:
           raise OSError("GITHUB_ENV doesn't exist!")
         github_env = open(github_env_path, "w")
 
-        github_event_filepath = "${{ inputs.github-event-path }}"
-        if github_event_filepath != "":
+        github_event_filepath = environ.get('GITHUB_EVENT_PATH', None)
+        if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
           client_payload = json.loads(inputs_dict["clientPayload"])

--- a/action.yaml
+++ b/action.yaml
@@ -121,7 +121,7 @@ runs:
           raise OSError("GITHUB_ENV doesn't exist!")
         github_env = open(github_env_path, "w")
 
-        github_event_filepath = environ.get('GITHUB_EVENT_PATH', None)
+        github_event_filepath = environ.get('GITHUB_EVENT_PATH', "")
         if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]

--- a/action.yaml
+++ b/action.yaml
@@ -130,7 +130,7 @@ runs:
         if github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
-          client_payload = json.loads(inputs_dict["client_payload"])
+          client_payload = json.loads(inputs_dict["clientPayload"])
           githubToken = client_payload["githubToken"]
           trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
         else:

--- a/action.yaml
+++ b/action.yaml
@@ -132,10 +132,10 @@ runs:
           inputs_dict = json.loads(github_event_text)["inputs"]
           client_payload = json.loads(inputs_dict["client_payload"])
           githubToken = client_payload["githubToken"]
-          trunkToken = client_payload["token"]
+          trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
         else:
           githubToken = "${{ inputs.github-token || fromJSON(inputs.json).githubToken }}"
-          trunkToken = "${{ inputs.trunk-token || fromJSON(inputs.json).token }}"
+          trunkToken = "${{ inputs.trunk-token || fromJSON(inputs.json).trunkToken || fromJSON(inputs.json).token }}"
           try:
             client_payload = json.loads('${{ inputs.json }}') # these must be single quotes
           except json.decoder.JSONDecodeError:


### PR DESCRIPTION
This is step 1 of 6 to clean up the trunk check workflow inputs:

1. change trunk-action to accept either clientPayload.token or clientPayload.trunkToken ([trunk-action#116](https://github.com/trunk-io/trunk-action/pull/116))
2. change .trunk-internal extra inputs to not be required and use github event path ([.trunk-internal#6](https://github.com/trunk-io/.trunk-internal/pull/6))
3. change monorepo to not have extra inputs ([trunk#9070](https://github.com/trunk-io/trunk/pull/9070))
4. staging deploy
5. change .trunk-internal to remove extra inputs ([.trunk-internal#7](https://github.com/trunk-io/.trunk-internal/pull/7))
6. change trunk action to not use json or token inputs ([trunk-action#117](https://github.com/trunk-io/trunk-action/pull/117))