### PR TITLE
fix: remove json and token inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,17 +57,6 @@ inputs:
     description: Steps to run after auto-init / before check
     required: false
 
-  github-token:
-    description: For overriding github.token
-    required: false
-
-  trunk-token:
-    description:
-      You can find a per-repo API token in the Trunk web app settings. This will cause results to be
-      uploaded to the Trunk web app if this job is a scheduled job running on a branch, or if
-      `check-mode` is set to 'all'.
-    required: false
-
   upload-series:
     description:
       Upload series name, for when `trunk-token` is provided. If not provided, we'll use the branch
@@ -97,10 +86,17 @@ inputs:
     required: false
     default: "false"
 
+<<<<<<< HEAD
   json:
     description: Used by CheckService
     required: false
     default: "{}"
+=======
+  github-event-path:
+    description: Used by CheckService
+    required: false
+    default: ""
+>>>>>>> 1203643 (remove old inputs)
 
   debug:
     description: Internal use only
@@ -121,20 +117,17 @@ runs:
           raise OSError("GITHUB_ENV doesn't exist!")
         github_env = open(github_env_path, "w")
 
-        github_event_filepath = environ.get('GITHUB_EVENT_PATH', None)
+        client_payload = None
+        githubToken = ""
+        trunkToken = ""
+
+        github_event_filepath = environ.get('GITHUB_EVENT_PATH', "")
         if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
           client_payload = json.loads(inputs_dict["payload"])
           githubToken = client_payload["githubToken"]
           trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
-        else:
-          githubToken = "${{ inputs.github-token || fromJSON(inputs.json).githubToken }}"
-          trunkToken = "${{ inputs.trunk-token || fromJSON(inputs.json).trunkToken || fromJSON(inputs.json).token }}"
-          try:
-            client_payload = json.loads('${{ inputs.json }}') # these must be single quotes
-          except json.decoder.JSONDecodeError:
-            client_payload = None
 
         print(f"::add-mask::{githubToken}")
         print(f"::add-mask::{trunkToken}")

--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,7 @@ runs:
         if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
-          client_payload = json.loads(inputs_dict["clientPayload"])
+          client_payload = json.loads(inputs_dict["payload"])
           githubToken = client_payload["githubToken"]
           trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
         else:

--- a/action.yaml
+++ b/action.yaml
@@ -97,11 +97,6 @@ inputs:
     required: false
     default: "false"
 
-  github-event-path:
-    description: Used by CheckService
-    required: false
-    default: ""
-
   json:
     description: Used by CheckService
     required: false
@@ -126,8 +121,8 @@ runs:
           raise OSError("GITHUB_ENV doesn't exist!")
         github_env = open(github_env_path, "w")
 
-        github_event_filepath = "${{ inputs.github-event-path }}"
-        if github_event_filepath != "":
+        github_event_filepath = environ.get('GITHUB_EVENT_PATH', None)
+        if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
           client_payload = json.loads(inputs_dict["clientPayload"])

--- a/action.yaml
+++ b/action.yaml
@@ -57,6 +57,17 @@ inputs:
     description: Steps to run after auto-init / before check
     required: false
 
+  github-token:
+    description: For overriding github.token
+    required: false
+
+  trunk-token:
+    description:
+      You can find a per-repo API token in the Trunk web app settings. This will cause results to be
+      uploaded to the Trunk web app if this job is a scheduled job running on a branch, or if
+      `check-mode` is set to 'all'.
+    required: false
+
   upload-series:
     description:
       Upload series name, for when `trunk-token` is provided. If not provided, we'll use the branch
@@ -86,18 +97,6 @@ inputs:
     required: false
     default: "false"
 
-<<<<<<< HEAD
-  json:
-    description: Used by CheckService
-    required: false
-    default: "{}"
-=======
-  github-event-path:
-    description: Used by CheckService
-    required: false
-    default: ""
->>>>>>> 1203643 (remove old inputs)
-
   debug:
     description: Internal use only
     required: false
@@ -118,16 +117,16 @@ runs:
         github_env = open(github_env_path, "w")
 
         client_payload = None
-        githubToken = ""
-        trunkToken = ""
+        githubToken = "${{ inputs.github-token }}"
+        trunkToken = "${{ inputs.trunk-token }}"
 
         github_event_filepath = environ.get('GITHUB_EVENT_PATH', "")
         if "${{ inputs.check-mode }}" == "payload" and github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
           client_payload = json.loads(inputs_dict["payload"])
-          githubToken = client_payload["githubToken"]
-          trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
+          githubToken = client_payload.get("githubToken", githubToken)
+          trunkToken = client_payload.get("trunkToken", client_payload.get("token", "trunkToken)
 
         print(f"::add-mask::{githubToken}")
         print(f"::add-mask::{trunkToken}")

--- a/action.yaml
+++ b/action.yaml
@@ -130,7 +130,7 @@ runs:
         if github_event_filepath != "":
           github_event_text = open(github_event_filepath).read()
           inputs_dict = json.loads(github_event_text)["inputs"]
-          client_payload = json.loads(inputs_dict["client_payload"])
+          client_payload = json.loads(inputs_dict["clientPayload"])
           githubToken = client_payload["githubToken"]
           trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
         else:

--- a/action.yaml
+++ b/action.yaml
@@ -132,10 +132,10 @@ runs:
           inputs_dict = json.loads(github_event_text)["inputs"]
           client_payload = json.loads(inputs_dict["client_payload"])
           githubToken = client_payload["githubToken"]
-          trunkToken = client_payload["token"]
+          trunkToken = client_payload.get("trunkToken", client_payload.get("token", ""))
         else:
           githubToken = "${{ inputs.github-token || fromJSON(inputs.json).githubToken }}"
-          trunkToken = "${{ inputs.trunk-token || fromJSON(inputs.json).token }}"
+          trunkToken = "${{ inputs.trunk-token || fromJSON(inputs.json).trunkToken || fromJSON(inputs.json).token }}"
           try:
             client_payload = json.loads('${{ inputs.json }}') # these must be single quotes
           except json.decoder.JSONDecodeError:


### PR DESCRIPTION
This is step 6 of 6 to clean up the trunk check workflow inputs:

1. change trunk-action to accept either clientPayload.token or clientPayload.trunkToken ([trunk-action#116](https://github.com/trunk-io/trunk-action/pull/116))
2. change .trunk-internal extra inputs to not be required and use github event path ([.trunk-internal#6](https://github.com/trunk-io/.trunk-internal/pull/6))
3. change monorepo to not have extra inputs ([trunk#9070](https://github.com/trunk-io/trunk/pull/9070))
4. staging deploy
5. change .trunk-internal to remove extra inputs ([.trunk-internal#7](https://github.com/trunk-io/.trunk-internal/pull/7))
6. change trunk action to not use json or token inputs ([trunk-action#117](https://github.com/trunk-io/trunk-action/pull/117))