### PR TITLE
Specify specific paths for upgrade

### DIFF
--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -43,6 +43,11 @@ inputs:
     description: A comma or newline separated list of GitHub reviewer usernames
     required: false
 
+  add-paths:
+    description: Specific paths to add to the created pull request. Comma separated.
+    required: false
+    default: .trunk
+
 runs:
   using: composite
   steps:
@@ -103,7 +108,7 @@ runs:
         base: ${{ inputs.base }}
         branch: trunk-io/update-trunk
         labels: trunk
-        add-paths: .trunk
+        add-paths: ${{ inputs.add-paths }}
         commit-message: ${{ env.PR_TITLE }}
         delete-branch: true
         reviewers: ${{ inputs.reviewers }}


### PR DESCRIPTION
Specify which paths should be added to the generated PR. Default `.trunk`, but needs to be `plugin.yaml` for https://github.com/trunk-io/configs/pull/3.

[Demonstrated successful run](https://github.com/trunk-io/configs/actions/runs/5204635588/jobs/9389113298?pr=3)