### PR TITLE
feat: wire through TRUNK_API_ADDRESS

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -174,7 +174,7 @@ runs:
         env_write(client_payload, "INPUT_UPLOAD_SERIES", "uploadSeries", "${{ inputs.upload-series }}")
         
         if "trunkApiAddress" in client_payload:
-          github_env.write(f"TRUNK_API_ADDRESS={client_payload["trunkApiAddress"]}\n")
+          github_env.write(f"TRUNK_API_ADDRESS={client_payload['trunkApiAddress']}\n")
 
     - name: Checkout
       if: env.INPUT_TARGET_CHECKOUT

--- a/action.yaml
+++ b/action.yaml
@@ -172,8 +172,8 @@ runs:
         env_write(client_payload, "INPUT_TRUNK_PATH", "trunkPath", "${{ inputs.trunk-path }}")
         env_write(client_payload, "INPUT_UPLOAD_LANDING_STATE", "uploadLandingState", "false")
         env_write(client_payload, "INPUT_UPLOAD_SERIES", "uploadSeries", "${{ inputs.upload-series }}")
-        
-        if "trunkApiAddress" in client_payload:
+
+        if client_payload is not None and "trunkApiAddress" in client_payload:
           github_env.write(f"TRUNK_API_ADDRESS={client_payload['trunkApiAddress']}\n")
 
     - name: Checkout

--- a/action.yaml
+++ b/action.yaml
@@ -134,6 +134,7 @@ runs:
         github_env.write("GITHUB_TOKEN=${{ github.token }}\n")
         github_env.write(f"INPUT_GITHUB_TOKEN={githubToken}\n")
         github_env.write(f"INPUT_TRUNK_TOKEN={trunkToken}\n")
+        github_env.write(f"TRUNK_TOKEN={trunkToken}\n")
 
         def env_write(payload, varname, path, backup):
           to_write = payload
@@ -171,6 +172,9 @@ runs:
         env_write(client_payload, "INPUT_TRUNK_PATH", "trunkPath", "${{ inputs.trunk-path }}")
         env_write(client_payload, "INPUT_UPLOAD_LANDING_STATE", "uploadLandingState", "false")
         env_write(client_payload, "INPUT_UPLOAD_SERIES", "uploadSeries", "${{ inputs.upload-series }}")
+        
+        if "trunkApiAddress" in client_payload:
+          github_env.write(f"TRUNK_API_ADDRESS={client_payload["trunkApiAddress"]}\n")
 
     - name: Checkout
       if: env.INPUT_TARGET_CHECKOUT


### PR DESCRIPTION
Teach trunk-action to always call the CheckService instance that dispatched it.

Also set TRUNK_TOKEN; we should stop using INPUT_TRUNK_TOKEN and explicitly wiring it through everywhere