### PR TITLE
fix: download trunk version before depending on its output

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -15,8 +15,6 @@ fetch() {
     "$@"
 }
 
-${trunk_path} # download trunk version here, so it doesn't output later
-
 if [[ ${TRUNK_CHECK_MODE} == "all" ]]; then
   if [[ -n ${INPUT_TRUNK_TOKEN} && ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     latest_raw_upload="$(mktemp)"

--- a/fetch.sh
+++ b/fetch.sh
@@ -15,6 +15,8 @@ fetch() {
     "$@"
 }
 
+${trunk_path} # download trunk version here, so it doesn't output later
+
 if [[ ${TRUNK_CHECK_MODE} == "all" ]]; then
   if [[ -n ${INPUT_TRUNK_TOKEN} && ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     latest_raw_upload="$(mktemp)"

--- a/locate_trunk.sh
+++ b/locate_trunk.sh
@@ -25,4 +25,4 @@ if [[ -z ${trunk_path} ]]; then
 fi
 echo "TRUNK_PATH=${trunk_path}" >>"${GITHUB_ENV}"
 # Ensure that trunk CLI is downloaded before subsequent steps
-${trunk_path} || echo "Warning: ${trunk_path} does not exist!"
+${trunk_path} || echo "::warning::${trunk_path} does not exist!"

--- a/locate_trunk.sh
+++ b/locate_trunk.sh
@@ -24,5 +24,5 @@ if [[ -z ${trunk_path} ]]; then
   fi
 fi
 echo "TRUNK_PATH=${trunk_path}" >>"${GITHUB_ENV}"
-# download trunk version here, so it doesn't output later
+# Ensure that trunk CLI is downloaded before subsequent steps
 ${trunk_path} || echo "Warning: ${trunk_path} does not exist!"

--- a/locate_trunk.sh
+++ b/locate_trunk.sh
@@ -24,3 +24,5 @@ if [[ -z ${trunk_path} ]]; then
   fi
 fi
 echo "TRUNK_PATH=${trunk_path}" >>"${GITHUB_ENV}"
+# download trunk version here, so it doesn't output later
+${trunk_path} || echo "Warning: ${trunk_path} does not exist!"

--- a/locate_trunk.sh
+++ b/locate_trunk.sh
@@ -24,4 +24,3 @@ if [[ -z ${trunk_path} ]]; then
   fi
 fi
 echo "TRUNK_PATH=${trunk_path}" >>"${GITHUB_ENV}"
-${trunk_path} # download trunk version here, so it doesn't output later

--- a/locate_trunk.sh
+++ b/locate_trunk.sh
@@ -24,3 +24,4 @@ if [[ -z ${trunk_path} ]]; then
   fi
 fi
 echo "TRUNK_PATH=${trunk_path}" >>"${GITHUB_ENV}"
+${trunk_path} # download trunk version here, so it doesn't output later


### PR DESCRIPTION
As seen in [this failing upload](https://github.com/trunk-io/trunk/actions/runs/5257114644/jobs/9499436500), if the launcher can't find the specified version of trunk in the cache, it downloads it and prints logs, which can output junk into variables that we use for logic.

This bandaid fixes the issue by running trunk immediately, downloading it and printing the logs before it can corrupt anything.