### PR TITLE
fix: always checkout with lfs=true

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -125,6 +125,7 @@ runs:
       if: env.INPUT_TARGET_CHECKOUT
       uses: actions/checkout@v3
       with:
+        lfs: true
         repository: ${{ env.INPUT_TARGET_CHECKOUT }}
         ref: ${{ env.INPUT_TARGET_CHECKOUT_REF }}
         token: ${{ env.INPUT_GITHUB_TOKEN }}


### PR DESCRIPTION
CheckService-driven invocations should always set this; it causes no issues with checking out repos without LFS artifacts.