### PR TITLE
fix: remove unnecessary calls to --token

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -74,7 +74,7 @@ jobs:
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (compat test for cli 1.0.0)
             post-init: |
-              echo "TRUNK_CLI_VERSION=1.0.0" >> >$GITHUB_ENV
+              echo "TRUNK_CLI_VERSION=1.0.0" >> $GITHUB_ENV
 
           - repo: sheldonhull/sheldonhull.hugo
             ref: 0810b7219c6681931bbf727cd9fe81693b414b60

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -63,7 +63,7 @@ jobs:
             description: (compat test for cli 1.0.0)
             post-init: |
               ${TRUNK_PATH} check enable eslint
-              echo "TRUNK_CLI_VERSION=1.0.0" >> $GITHUB_ENV
+              # echo "TRUNK_CLI_VERSION=1.0.0" >> $GITHUB_ENV
 
           - repo: replayio/devtools
             ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac
@@ -139,6 +139,9 @@ jobs:
           arguments: --output-file=.trunk/landing-state.json
           cache-key: repo_tests/${{ matrix.repo }}
           setup-deps: true
+        env:
+          TRUNK_CLI_VERSION:
+            ${{ matrix.description == '(compat test for cli 1.0.0)' && '1.0.0' || '' }}
         continue-on-error: true
 
       - name: Check for task failures

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -70,6 +70,12 @@ jobs:
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
 
+          - repo: sass/sass
+            ref: 225e176115211387e014d97ae0076d94de3152a1
+            description: (compat test for cli 1.0.0)
+            post-init: |
+              echo "TRUNK_CLI_VERSION=1.0.0" >> >$GITHUB_ENV
+
           - repo: sheldonhull/sheldonhull.hugo
             ref: 0810b7219c6681931bbf727cd9fe81693b414b60
             description: (has trunk.yaml)

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -63,7 +63,6 @@ jobs:
             description: (compat test for cli 1.0.0)
             post-init: |
               ${TRUNK_PATH} check enable eslint
-              # echo "TRUNK_CLI_VERSION=1.0.0" >> $GITHUB_ENV
 
           - repo: replayio/devtools
             ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -58,6 +58,13 @@ jobs:
             post-init: |
               ${TRUNK_PATH} check enable eslint
 
+          - repo: postcss/postcss
+            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
+            description: (compat test for cli 1.0.0)
+            post-init: |
+              ${TRUNK_PATH} check enable eslint
+              echo "TRUNK_CLI_VERSION=1.0.0" >> $GITHUB_ENV
+
           - repo: replayio/devtools
             ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac
             description: (has trunk.yaml)
@@ -69,12 +76,6 @@ jobs:
           - repo: sass/sass
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
-
-          - repo: sass/sass
-            ref: 225e176115211387e014d97ae0076d94de3152a1
-            description: (compat test for cli 1.0.0)
-            post-init: |
-              echo "TRUNK_CLI_VERSION=1.0.0" >> $GITHUB_ENV
 
           - repo: sheldonhull/sheldonhull.hugo
             ref: 0810b7219c6681931bbf727cd9fe81693b414b60

--- a/action.yaml
+++ b/action.yaml
@@ -277,7 +277,6 @@ runs:
         "${TRUNK_PATH}" check finalize-github-check-run \
           --target "${INPUT_TARGET_CHECKOUT}" \
           --check_run_id "${INPUT_CHECK_RUN_ID}" \
-          --token "${INPUT_TRUNK_TOKEN}"
 
     - name: Upload landing state
       if: env.INPUT_UPLOAD_LANDING_STATE

--- a/fetch.sh
+++ b/fetch.sh
@@ -16,13 +16,12 @@ fetch() {
 }
 
 if [[ ${TRUNK_CHECK_MODE} == "all" ]]; then
-  if [[ -n ${INPUT_TRUNK_TOKEN} && ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
+  if [[ -n ${TRUNK_TOKEN} && ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     latest_raw_upload="$(mktemp)"
     # Note: the order of these if clauses is important. We can't invert them using if ! because that
     # would cause the exit code of prev_ref=$(...) to get discarded
     if prev_ref="$("${TRUNK_PATH}" check get-latest-raw-output \
       --series "${INPUT_UPLOAD_SERIES:-${GITHUB_REF_NAME}}" \
-      --token "${INPUT_TRUNK_TOKEN}" \
       "${latest_raw_upload}")"; then
       if [[ ${prev_ref} =~ .*UNSPECIFIED.* ]]; then
         echo "TRUNK_CHECK_ALL_HTL_ARG=" >>"${GITHUB_ENV}"

--- a/pull_request.sh
+++ b/pull_request.sh
@@ -38,21 +38,10 @@ else
   annotation_argument=--github-annotate
 fi
 
-if [[ -n ${INPUT_TRUNK_TOKEN} ]]; then
-  "${TRUNK_PATH}" check \
-    --ci \
-    --upstream "${upstream}" \
-    --github-commit "${git_commit}" \
-    --github-label "${INPUT_LABEL}" \
-    --token "${INPUT_TRUNK_TOKEN}" \
-    "${annotation_argument}" \
-    ${INPUT_ARGUMENTS}
-else
-  "${TRUNK_PATH}" check \
-    --ci \
-    --upstream "${upstream}" \
-    --github-commit "${git_commit}" \
-    --github-label "${INPUT_LABEL}" \
-    "${annotation_argument}" \
-    ${INPUT_ARGUMENTS}
-fi
+"${TRUNK_PATH}" check \
+  --ci \
+  --upstream "${upstream}" \
+  --github-commit "${git_commit}" \
+  --github-label "${INPUT_LABEL}" \
+  "${annotation_argument}" \
+  ${INPUT_ARGUMENTS}

--- a/repo_tests/check_for_task_failures.py
+++ b/repo_tests/check_for_task_failures.py
@@ -12,6 +12,10 @@ def main(github_env_path, repo_test_name, repo_test_description):
     sys.exit(1)
     return
 
+  print("::group::landing state")
+  print(landing_state)
+  print("::endgroup::")
+
   lint_action_count = len(landing_state.get("lintActions", []))
   task_failure_count = len(landing_state.get("taskFailures", []))
 

--- a/repo_tests/check_for_task_failures.py
+++ b/repo_tests/check_for_task_failures.py
@@ -12,10 +12,6 @@ def main(github_env_path, repo_test_name, repo_test_description):
     sys.exit(1)
     return
 
-  print("::group::landing state")
-  print(landing_state)
-  print("::endgroup::")
-
   lint_action_count = len(landing_state.get("lintActions", []))
   task_failure_count = len(landing_state.get("taskFailures", []))
 

--- a/trunk_merge.sh
+++ b/trunk_merge.sh
@@ -18,21 +18,10 @@ else
   annotation_argument=""
 fi
 
-if [[ -n ${INPUT_TRUNK_TOKEN} ]]; then
-  "${TRUNK_PATH}" check \
-    --ci \
-    --upstream "${upstream}" \
-    --github-commit "${git_commit}" \
-    --github-label "${INPUT_LABEL}" \
-    --token "${INPUT_TRUNK_TOKEN}" \
-    "${annotation_argument}" \
-    ${INPUT_ARGUMENTS}
-else
-  "${TRUNK_PATH}" check \
-    --ci \
-    --upstream "${upstream}" \
-    --github-commit "${git_commit}" \
-    --github-label "${INPUT_LABEL}" \
-    "${annotation_argument}" \
-    ${INPUT_ARGUMENTS}
-fi
+"${TRUNK_PATH}" check \
+  --ci \
+  --upstream "${upstream}" \
+  --github-commit "${git_commit}" \
+  --github-label "${INPUT_LABEL}" \
+  "${annotation_argument}" \
+  ${INPUT_ARGUMENTS}


### PR DESCRIPTION
Fixes [TRUNK-7598](https://linear.app/trunk/issue/TRUNK-7598/stop-passing-token-explicitly-in-trunk-action) - we can infer the trunk token from the TRUNK_TOKEN environment variable, so we don't need to pass it in with `--token` in most calls to the cli. The exception is in check-mode all, which is the path taken by cli version 1.0.0.

This PR removes most calls to `--token`, and adds a compatibility test to repo_tests for 1.0.0.