### PR TITLE
fix: correctly add token from input

### DIFF
--- a/input-setup/mask.js
+++ b/input-setup/mask.js
@@ -28,8 +28,8 @@ function run() {
     }
 
     const githubEnv = fs.openSync(process.env.GITHUB_ENV, "a");
-    const githubToken = payload?.githubToken ?? inputs["githubToken"] ?? "";
-    const trunkToken = payload?.trunkToken ?? inputs["trunkToken"] ?? "";
+    const githubToken = payload?.githubToken ?? inputs["github-token"] ?? "";
+    const trunkToken = payload?.trunkToken ?? inputs["trunk-token"] ?? "";
 
     process.stdout.write(`::add-mask::${githubToken}\n`);
     process.stdout.write(`::add-mask::${trunkToken}\n`);


### PR DESCRIPTION
Tested on a workflow run [here](https://github.com/trunk-io/trunk/actions/runs/5316026661/jobs/9625099192) on [maverick/test-actions-token-typo-fix](https://github.com/trunk-io/trunk/tree/maverick/test-actions-token-typo-fix) in the monorepo (run just on pylint so it doesn't take forever)

We haven't been correctly propagating the trunk token, causing our upload workflows to fail, just running trunk check rather than uploading the issues. As a result, it "fixes" [TRUNK-7582](https://linear.app/trunk/issue/TRUNK-7582/check-upload-should-not-print-detected-issues) - the reason we were printing the issues is because we weren't running the upload.