### PR TITLE
fix: job success should reflect trunk check success

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -343,17 +343,8 @@ runs:
       env:
         GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
-    - name: Finalize check run
-      if: always() && env.INPUT_CHECK_RUN_ID
-      continue-on-error: true
-      shell: bash
-      run: |
-        "${TRUNK_PATH}" check finalize-github-check-run \
-          --target "${INPUT_TARGET_CHECKOUT}" \
-          --check_run_id "${INPUT_CHECK_RUN_ID}" \
-
     - name: Upload landing state
-      if: env.INPUT_UPLOAD_LANDING_STATE
+      if: env.INPUT_UPLOAD_LANDING_STATE == 'true'
       continue-on-error: true
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
* If `trunk check` fails, the job should fail; right now it always succeeds because the finalize step has `always()` and `continue-on-error: true`
  * c.f. https://github.com/trunk-io/.trunk-internal/actions/runs/5405370271/jobs/9820824695
* Landing state upload should only happen if set to `"true"`
  * c.f. https://github.com/sxlijin/repro/actions/runs/5405792565/jobs/9821834283
* We no longer need to do client-side finalization, because we do it all from CheckService