### PR TITLE
fix: re-enable bandit on flask repo test

### DIFF
--- a/.github/workflows/docker_repo_tests.yaml
+++ b/.github/workflows/docker_repo_tests.yaml
@@ -36,8 +36,6 @@ jobs:
           - repo: pallets/flask
             ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
             post-init: |
-              # bandit is outputting a progress bar (TODO: TRUNK-7656)
-              ${TRUNK_PATH} check disable bandit
               # prettier chokes on this malformed html file
               echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
               cp local-action/repo_tests/flask.yaml .trunk/user.yaml

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -48,8 +48,6 @@ jobs:
           - repo: pallets/flask
             ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
             post-init: |
-              # bandit is outputting a progress bar (TODO: TRUNK-7656)
-              ${TRUNK_PATH} check disable bandit
               # prettier chokes on this malformed html file
               echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
               cp local-action/repo_tests/flask.yaml .trunk/user.yaml


### PR DESCRIPTION
TRUNK-7656 has been fixed, so we can re-enable bandit.