### PR TITLE
fix: make trunk_merge work again when invoked normally

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -49,8 +49,9 @@ jobs:
 
       - name: Run test
         shell: bash
-        run:
-          cd repo-under-test git checkout trunk-merge/of-feature-branch
+        run: |
+          cd repo-under-test
+          git checkout trunk-merge/of-feature-branch
           ./local-action/trunk_merge.sh
         env:
           INPUT_ARGUMENTS: ""

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -53,13 +53,13 @@ jobs:
         run: |
           cd repo-under-test
           git checkout trunk-merge/of-feature-branch
-          ./local-action/trunk_merge.sh
+          ../local-action/trunk_merge.sh
         env:
           INPUT_ARGUMENTS: ""
           INPUT_CHECK_RUN_ID: ""
           INPUT_DEBUG: ""
           INPUT_LABEL: ""
-          TRUNK_PATH: ./local-action/action_tests/stub.js
+          TRUNK_PATH: ../local-action/action_tests/stub.js
 
       - name: Assert expected
         shell: bash

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -64,5 +64,6 @@ jobs:
       - name: Assert expected
         shell: bash
         run: |
+          cd local-action
           npm install
-          ./local-action/action_tests/assert.js
+          ./action_tests/assert.js

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -46,12 +46,12 @@ jobs:
           cd ..
 
           git clone src-repo repo-under-test
-          cd repo-under-test
-          git checkout trunk-merge/of-feature-branch
 
       - name: Run test
         shell: bash
-        run: ./local-action/trunk_merge.sh
+        run:
+          cd repo-under-test git checkout trunk-merge/of-feature-branch
+          ./local-action/trunk_merge.sh
         env:
           INPUT_ARGUMENTS: ""
           INPUT_CHECK_RUN_ID: ""

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -1,0 +1,65 @@
+name: action_tests
+on: [workflow_dispatch, workflow_call]
+
+permissions: read-all
+
+jobs:
+  trunk_merge:
+    runs-on: ubuntu-latest
+    env:
+      TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - uses: actions/checkout@v3
+        with:
+          path: src-repo
+          repository: prawn-test-staging-rw/check-web
+
+      - name: Set up trunk merge test
+        shell: bash
+        run: |
+          cd src-repo
+
+          git config user.name 'trunk-io/trunk-action action_tests.trunk_merge'
+          git config user.email 'action_tests@trunk-action.trunk.io'
+
+          main=$(git rev-parse HEAD)
+
+          git checkout -b feature-branch
+
+          echo "markdown file for merge test" >>merge-test.md
+          git add .
+          git commit --all --message 'add file for merge test setup'
+
+          git checkout -b trunk-merge/of-feature-branch main
+
+          git merge --no-ff --no-edit feature-branch
+
+          echo "EXPECTED_UPSTREAM=$(git rev-parse HEAD^1)" >>$GITHUB_ENV
+          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse HEAD^2)" >>$GITHUB_ENV
+
+          cd ..
+
+          git clone src-repo repo-under-test
+          cd repo-under-test
+          git checkout trunk-merge/of-feature-branch
+
+      - name: Run test
+        shell: bash
+        run: ./local-action/trunk_merge.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_RUN_ID: ""
+          INPUT_DEBUG: ""
+          INPUT_LABEL: ""
+          TRUNK_PATH: ./local-action/action_tests/stub.js
+
+      - name: Assert expected
+        shell: bash
+        run: |
+          ./local-action/action_tests/assert.js

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -10,12 +10,7 @@ jobs:
       TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
 
     steps:
-      - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v3
-        with:
-          path: local-action
-
-      - uses: actions/checkout@v3
+      - uses: Set up source repo
         with:
           path: src-repo
           repository: prawn-test-staging-rw/check-web
@@ -46,6 +41,11 @@ jobs:
           cd ..
 
           git clone src-repo repo-under-test
+
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v3
+        with:
+          path: local-action
 
       - name: Run test
         shell: bash

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -64,4 +64,5 @@ jobs:
       - name: Assert expected
         shell: bash
         run: |
+          npm install
           ./local-action/action_tests/assert.js

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -10,7 +10,8 @@ jobs:
       TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
 
     steps:
-      - uses: Set up source repo
+      - name: Set up source repo
+        uses: actions/checkout@v3
         with:
           path: src-repo
           repository: prawn-test-staging-rw/check-web

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,6 +24,10 @@ jobs:
     name: Repository tests
     uses: ./.github/workflows/repo_tests.yaml
 
+  action_tests:
+    name: Action tests
+    uses: ./.github/workflows/action_tests.yaml
+
   docker_repo_tests:
     name: Repository tests (docker)
     uses: ./.github/workflows/docker_repo_tests.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__/
 *.py[cod]
 *$py.class
+
+# from https://github.com/github/gitignore/blob/main/Node.gitignore
+node_modules/

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const chai = require("chai");
+const fs = require("fs");
+
+const { expect } = chai;
+
+const stubLog = fs.readFileSync(process.env.TRUNK_STUB_LOGS, "utf8").split("\n");
+
+// The last element of the split() should be an empty string
+expect(stubLog.slice(-1)).to.deep.equal([""]);
+
+// Strip the last element before JSON.parse, because '' is not valid JSON.
+expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal([
+  [
+    "trunk",
+    "check",
+    "--ci",
+    "--upstream",
+    process.env.EXPECTED_UPSTREAM,
+    "--github-commit",
+    process.env.EXPECTED_GITHUB_COMMIT,
+    "--github-label",
+    "",
+  ],
+]);

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -3,12 +3,21 @@
 const fs = require("fs");
 const path = require("node:path");
 
+const getArgv = () => {
+  if (path.basename(process.argv[1]) === "stub.js") {
+    return ["trunk"].concat(process.argv.slice(2));
+  }
+
+  console.warn("Failed to sanitize argv", {
+    argv: process.argv,
+    basename: path.basename(process.argv[1]),
+  });
+  return process.argv;
+};
+
 // process.argv will look like ['/abs/path/to/node', '/abs/path/to/stub.js', ...]
 // We only want to assert that the calls look like ['trunk', 'check', '--ci', ...], hence the rewrite
-const argv =
-  path.basename(process.argv[1]) === "stub.js"
-    ? ["trunk"].concat(process.argv.slice(2))
-    : process.argv;
+const argv = getArgv();
 
 fs.appendFileSync(process.env.TRUNK_STUB_LOGS, JSON.stringify(process.argv));
 fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -4,17 +4,6 @@ const fs = require("fs");
 const path = require("node:path");
 
 const getArgv = () => {
-  fs.appendFileSync(
-    process.env.TRUNK_STUB_LOGS,
-    JSON.stringify({
-      argv: process.argv,
-      basename: path.basename(process.argv[1]),
-      first: true,
-      slice: ["trunk"].concat(process.argv.slice(2)),
-    })
-  );
-  fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
-
   if (path.basename(process.argv[1]) === "stub.js") {
     return ["trunk"].concat(process.argv.slice(2));
   }
@@ -22,8 +11,8 @@ const getArgv = () => {
   fs.appendFileSync(
     process.env.TRUNK_STUB_LOGS,
     JSON.stringify({
+      error: "Failed to sanitize argv",
       argv: process.argv,
-      basename: path.basename(process.argv[1]),
     })
   );
   fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
@@ -34,5 +23,5 @@ const getArgv = () => {
 // We only want to assert that the calls look like ['trunk', 'check', '--ci', ...], hence the rewrite
 const argv = getArgv();
 
-fs.appendFileSync(process.env.TRUNK_STUB_LOGS, JSON.stringify(process.argv));
+fs.appendFileSync(process.env.TRUNK_STUB_LOGS, JSON.stringify(argv));
 fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("node:path");
+
+// process.argv will look like ['/abs/path/to/node', '/abs/path/to/stub.js', ...]
+// We only want to assert that the calls look like ['trunk', 'check', '--ci', ...], hence the rewrite
+const argv =
+  path.basename(process.argv[1]) === "stub.js"
+    ? ["trunk"].concat(process.argv.slice(2))
+    : process.argv;
+
+fs.appendFileSync(process.env.TRUNK_STUB_LOGS, JSON.stringify(process.argv));
+fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -4,6 +4,17 @@ const fs = require("fs");
 const path = require("node:path");
 
 const getArgv = () => {
+  fs.appendFileSync(
+    process.env.TRUNK_STUB_LOGS,
+    JSON.stringify({
+      argv: process.argv,
+      basename: path.basename(process.argv[1]),
+      first: true,
+      slice: ["trunk"].concat(process.argv.slice(2)),
+    })
+  );
+  fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
+
   if (path.basename(process.argv[1]) === "stub.js") {
     return ["trunk"].concat(process.argv.slice(2));
   }

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -8,10 +8,14 @@ const getArgv = () => {
     return ["trunk"].concat(process.argv.slice(2));
   }
 
-  console.warn("Failed to sanitize argv", {
-    argv: process.argv,
-    basename: path.basename(process.argv[1]),
-  });
+  fs.appendFileSync(
+    process.env.TRUNK_STUB_LOGS,
+    JSON.stringify({
+      argv: process.argv,
+      basename: path.basename(process.argv[1]),
+    })
+  );
+  fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
   return process.argv;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,145 @@
+{
+  "name": "action",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "chai": "^4.3.7"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA=="
+    },
+    "deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig=="
+    },
+    "loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "chai": "^4.3.7"
+  }
+}

--- a/trunk_merge.sh
+++ b/trunk_merge.sh
@@ -32,5 +32,5 @@ fi
   --upstream "${upstream}" \
   --github-commit "${git_commit}" \
   --github-label "${INPUT_LABEL}" \
-  "${annotation_argument}" \
+  ${annotation_argument} \
   ${INPUT_ARGUMENTS}


### PR DESCRIPTION
Passing `"${annotation_argument}"` results in another empty string being passed into `trunk check` during `trunk_merge.sh`, which the CLI interprets as "attempt to lint the file with name `""`".

Passing `${annotation_argument}` results in Bash not passing anything to `trunk check`, which results in the correct behavior.

Also set up tests for `trunk_merge.sh` - it's not the greatest, but it's better than nothing.