### PR TITLE
fix: use correct regex for new series in all.sh

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -3,56 +3,29 @@ on: [workflow_dispatch, workflow_call]
 
 permissions: read-all
 
+env:
+  TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
+
 jobs:
   trunk_merge:
     runs-on: ubuntu-latest
-    env:
-      TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
-
     steps:
-      - name: Set up source repo
-        uses: actions/checkout@v3
-        with:
-          path: src-repo
-          repository: prawn-test-staging-rw/check-web
-
-      - name: Set up trunk merge test
-        shell: bash
-        run: |
-          cd src-repo
-
-          git config user.name 'trunk-io/trunk-action action_tests.trunk_merge'
-          git config user.email 'action_tests@trunk-action.trunk.io'
-
-          main=$(git rev-parse HEAD)
-
-          git checkout -b feature-branch
-
-          echo "markdown file for merge test" >>merge-test.md
-          git add .
-          git commit --all --message 'add file for merge test setup'
-
-          git checkout -b trunk-merge/of-feature-branch main
-
-          git merge --no-ff --no-edit feature-branch
-
-          echo "EXPECTED_UPSTREAM=$(git rev-parse HEAD^1)" >>$GITHUB_ENV
-          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse HEAD^2)" >>$GITHUB_ENV
-
-          cd ..
-
-          git clone src-repo repo-under-test
-
-      - name: Checkout ${{ github.repository }}
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           path: local-action
 
-      - name: Run test
+      - name: Set up test
+        shell: bash
+        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+
+      - name: Run trunk-action
         shell: bash
         run: |
           cd repo-under-test
           git checkout trunk-merge/of-feature-branch
+          echo "EXPECTED_UPSTREAM=$(git rev-parse trunk-merge/of-feature-branch^1)" >>$GITHUB_ENV
+          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse trunk-merge/of-feature-branch^2)" >>$GITHUB_ENV
           ../local-action/trunk_merge.sh
         env:
           INPUT_ARGUMENTS: ""
@@ -61,9 +34,75 @@ jobs:
           INPUT_LABEL: ""
           TRUNK_PATH: ../local-action/action_tests/stub.js
 
-      - name: Assert expected
+      - name: Assert CLI calls
         shell: bash
         run: |
           cd local-action
           npm install
-          ./action_tests/assert.js
+          ./action_tests/assert.js trunk-merge
+
+  all-hold-the-line-new-series:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+
+      - name: Run trunk-action
+        shell: bash
+        run: |
+          cd repo-under-test
+          ../local-action/all.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_ALL_MODE: hold-the-line
+          INPUT_DEBUG: ""
+          INPUT_TRUNK_TOKEN: trunk-token
+          INPUT_UPLOAD_SERIES: series-name
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+          STUB_GET_LATEST_RAW_OUTPUT_STDOUT: "Starting new series of check runs...\n"
+
+      - name: Assert CLI calls
+        shell: bash
+        run: |
+          cd local-action
+          npm install
+          ./action_tests/assert.js all-hold-the-line-first-upload
+
+  all-hold-the-line-existing-series:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+
+      - name: Run trunk-action
+        shell: bash
+        run: |
+          cd repo-under-test
+          ../local-action/all.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_ALL_MODE: hold-the-line
+          INPUT_DEBUG: ""
+          INPUT_TRUNK_TOKEN: trunk-token
+          INPUT_UPLOAD_SERIES: series-name
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+          STUB_GET_LATEST_RAW_OUTPUT_STDOUT: abcdef123456
+
+      - name: Assert CLI calls
+        shell: bash
+        run: |
+          cd local-action
+          npm install
+          ./action_tests/assert.js all-hold-the-line-existing-series

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           cd local-action
           npm install
-          ./action_tests/assert.js all-hold-the-line-first-upload
+          ./action_tests/assert.js all-hold-the-line-new-series
 
   all-hold-the-line-existing-series:
     runs-on: ubuntu-latest

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -4,6 +4,7 @@ on: [workflow_dispatch, workflow_call]
 permissions: read-all
 
 env:
+  TMPDIR: /tmp/trunk-stub-tmp
   TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
 
 jobs:
@@ -84,7 +85,10 @@ jobs:
 
       - name: Set up test
         shell: bash
-        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+        run: |
+          ./local-action/action_tests/setup.sh src-repo repo-under-test
+          cd repo-under-test
+          echo "EXPECTED_UPSTREAM=$(git rev-parse main^)" >>$GITHUB_ENV
 
       - name: Run trunk-action
         shell: bash
@@ -98,7 +102,7 @@ jobs:
           INPUT_TRUNK_TOKEN: trunk-token
           INPUT_UPLOAD_SERIES: series-name
           TRUNK_PATH: ../local-action/action_tests/stub.js
-          STUB_GET_LATEST_RAW_OUTPUT_STDOUT: abcdef123456
+          STUB_GET_LATEST_RAW_OUTPUT_STDOUT: ${{ env.EXPECTED_UPSTREAM }}
 
       - name: Assert CLI calls
         shell: bash

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,13 +20,13 @@ jobs:
       - name: Trunk Check
         uses: ./ # external users, use: trunk-io/trunk-action@v1
 
-  repo_tests:
-    name: Repository tests
-    uses: ./.github/workflows/repo_tests.yaml
-
   action_tests:
     name: Action tests
     uses: ./.github/workflows/action_tests.yaml
+
+  repo_tests:
+    name: Repository tests
+    uses: ./.github/workflows/repo_tests.yaml
 
   docker_repo_tests:
     name: Repository tests (docker)

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -10,17 +10,29 @@ const stubLog = fs.readFileSync(process.env.TRUNK_STUB_LOGS, "utf8").split("\n")
 // The last element of the split() should be an empty string
 expect(stubLog.slice(-1)).to.deep.equal([""]);
 
-// Strip the last element before JSON.parse, because '' is not valid JSON.
-expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal([
-  [
-    "trunk",
-    "check",
-    "--ci",
-    "--upstream",
-    process.env.EXPECTED_UPSTREAM,
-    "--github-commit",
-    process.env.EXPECTED_GITHUB_COMMIT,
-    "--github-label",
-    "",
+const EXPECTED_OUTPUTS = {
+  "trunk-merge": [
+    [
+      "trunk",
+      "check",
+      "--ci",
+      "--upstream",
+      process.env.EXPECTED_UPSTREAM,
+      "--github-commit",
+      process.env.EXPECTED_GITHUB_COMMIT,
+      "--github-label",
+      "",
+    ],
   ],
-]);
+  "all-hold-the-line-new-series": [
+    ["trunk", "check", "get-latest-raw-output", "--series", "series-name"],
+    ["trunk", "check", "--all", "--upload", "--series", "series-name"],
+  ],
+  "all-hold-the-line-existing-series": [
+    ["trunk", "check", "get-latest-raw-output", "--series", "series-name"],
+    ["trunk", "check", "--all", "--upload", "--series", "series-name"],
+  ],
+};
+
+// Strip the last element before JSON.parse, because '' is not valid JSON.
+expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal(EXPECTED_OUTPUTS.get(process.argv[2]));

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -11,10 +11,28 @@ const stubLog = fs.readFileSync(process.env.TRUNK_STUB_LOGS, "utf8").split("\n")
 // The last element of the split() should be an empty string
 expect(stubLog.slice(-1)).to.deep.equal([""]);
 
-const mktempReturned = path.join(process.env.TMPDIR, fs.readdirSync(process.env.TMPDIR)[0]);
+const getHtlFactoriesPath = () => {
+  const tmpdirContents = fs.readdirSync(process.env.TMPDIR);
 
-const EXPECTED_CLI_CALLS_BY_TEST_CASE = {
-  "trunk-merge": [
+  if (tmpdirContents.length === 0) {
+    throw new Error(
+      `TMPDIR=${process.env.TMPDIR} was empty; could not infer what --htl-factories-path should have been`
+    );
+  }
+
+  if (tmpdirContents.length > 1) {
+    throw new Error(
+      `TMPDIR=${process.env.TMPDIR} had multiple entries (${JSON.stringify(
+        tmpdirContents
+      )}); could not infer what --htl-factories-path should have been`
+    );
+  }
+
+  return path.join(process.env.TMPDIR, tmpdirContents[0]);
+};
+
+const EXPECTED_CLI_CALL_FACTORIES = {
+  "trunk-merge": () => [
     [
       "trunk",
       "check",
@@ -27,25 +45,25 @@ const EXPECTED_CLI_CALLS_BY_TEST_CASE = {
       "",
     ],
   ],
-  "all-hold-the-line-new-series": [
-    ["trunk", "check", "get-latest-raw-output", "--series", "series-name", mktempReturned],
+  "all-hold-the-line-new-series": () => [
+    ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],
     ["trunk", "check", "--all", "--upload", "--series", "series-name"],
   ],
-  "all-hold-the-line-existing-series": [
-    ["trunk", "check", "get-latest-raw-output", "--series", "series-name"],
+  "all-hold-the-line-existing-series": () => [
+    ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],
     [
       "trunk",
       "check",
       "--all",
       "--upload",
-      `--htl-factories-path=${mktempReturned}`,
+      `--htl-factories-path=${getHtlFactoriesPath()}`,
       "--series",
       "series-name",
     ],
   ],
 };
 
-const expectedCliCalls = EXPECTED_CLI_CALLS_BY_TEST_CASE[process.argv[2]];
+const expectedCliCalls = EXPECTED_CLI_CALL_FACTORIES[process.argv[2]]();
 
 // Strip the last element before JSON.parse, because '' is not valid JSON.
 expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal(expectedCliCalls);

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -2,6 +2,7 @@
 
 const chai = require("chai");
 const fs = require("fs");
+const path = require("path");
 
 const { expect } = chai;
 
@@ -9,6 +10,8 @@ const stubLog = fs.readFileSync(process.env.TRUNK_STUB_LOGS, "utf8").split("\n")
 
 // The last element of the split() should be an empty string
 expect(stubLog.slice(-1)).to.deep.equal([""]);
+
+const mktempReturned = path.join(process.env.TMPDIR, fs.readdirSync(process.env.TMPDIR)[0]);
 
 const EXPECTED_CLI_CALLS_BY_TEST_CASE = {
   "trunk-merge": [
@@ -25,12 +28,20 @@ const EXPECTED_CLI_CALLS_BY_TEST_CASE = {
     ],
   ],
   "all-hold-the-line-new-series": [
-    ["trunk", "check", "get-latest-raw-output", "--series", "series-name"],
+    ["trunk", "check", "get-latest-raw-output", "--series", "series-name", mktempReturned],
     ["trunk", "check", "--all", "--upload", "--series", "series-name"],
   ],
   "all-hold-the-line-existing-series": [
     ["trunk", "check", "get-latest-raw-output", "--series", "series-name"],
-    ["trunk", "check", "--all", "--upload", "--series", "series-name"],
+    [
+      "trunk",
+      "check",
+      "--all",
+      "--upload",
+      `--htl-factories-path=${mktempReturned}`,
+      "--series",
+      "series-name",
+    ],
   ],
 };
 

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -63,7 +63,12 @@ const EXPECTED_CLI_CALL_FACTORIES = {
   ],
 };
 
-const expectedCliCalls = EXPECTED_CLI_CALL_FACTORIES[process.argv[2]]();
+const testCase = process.argv[2];
+const expectedCliCalls = EXPECTED_CLI_CALL_FACTORIES[testCase]();
 
 // Strip the last element before JSON.parse, because '' is not valid JSON.
-expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal(expectedCliCalls);
+const actualCliCalls = stubLog.slice(0, -1).map(JSON.parse);
+
+expect(actualCliCalls).to.deep.equal(expectedCliCalls);
+
+console.log(`Test passed: ${testCase}\n\nCLI calls were:\n${JSON.stringify(actualCliCalls)}`);

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -10,7 +10,7 @@ const stubLog = fs.readFileSync(process.env.TRUNK_STUB_LOGS, "utf8").split("\n")
 // The last element of the split() should be an empty string
 expect(stubLog.slice(-1)).to.deep.equal([""]);
 
-const EXPECTED_OUTPUTS = {
+const EXPECTED_CLI_CALLS_BY_TEST_CASE = {
   "trunk-merge": [
     [
       "trunk",
@@ -34,5 +34,7 @@ const EXPECTED_OUTPUTS = {
   ],
 };
 
+const expectedCliCalls = EXPECTED_CLI_CALLS_BY_TEST_CASE[process.argv[2]];
+
 // Strip the last element before JSON.parse, because '' is not valid JSON.
-expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal(EXPECTED_OUTPUTS.get(process.argv[2]));
+expect(stubLog.slice(0, -1).map(JSON.parse)).to.deep.equal(expectedCliCalls);

--- a/action_tests/setup.sh
+++ b/action_tests/setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+src_repo=$1
+output_repo=$2
+
+## Set up repo in `src_repo`
+
+mkdir -p "${src_repo}"
+(
+  cd "${src_repo}"
+
+  git init
+
+  git config user.name 'trunk-io/trunk-action action_tests.trunk_merge'
+  git config user.email 'action_tests@trunk-action.trunk.io'
+
+  echo "This is a README." >>readme.md
+  git add .
+  git commit --all --message 'First commit'
+
+  echo "These are contribution guidelines." >>contributing.md
+  git add .
+  git commit --all --message 'Second commit'
+
+  ## Prepare a branch `feature-branch`
+
+  git checkout -b feature-branch main^
+
+  echo "markdown file for merge test" >>merge-test.md
+  git add .
+  git commit --all --message 'add file for merge test setup'
+
+  ## Prepare a merge graph commit
+
+  git checkout -b trunk-merge/of-feature-branch main
+
+  git merge --no-ff --no-edit feature-branch
+
+  ## Go back to `main`
+
+  git checkout main
+
+  ## Dump the state of the repo
+
+  git log --graph --pretty=oneline trunk-merge/of-feature-branch
+)
+
+## Set up repo in `output_repo`
+
+git clone "${src_repo}" "${output_repo}"

--- a/action_tests/setup.sh
+++ b/action_tests/setup.sh
@@ -52,3 +52,7 @@ mkdir -p "${src_repo}"
 ## Set up repo in `output_repo`
 
 git clone "${src_repo}" "${output_repo}"
+
+## Force mktemp to point at TMPDIR
+
+mkdir -p "${TMPDIR}"

--- a/action_tests/setup.sh
+++ b/action_tests/setup.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 src_repo=$1
 output_repo=$2
 
+git config --global init.defaultBranch main
+
 ## Set up repo in `src_repo`
 
 mkdir -p "${src_repo}"

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -25,3 +25,7 @@ const argv = getArgv();
 
 fs.appendFileSync(process.env.TRUNK_STUB_LOGS, JSON.stringify(argv));
 fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
+
+if (argv[1] === "check" && argv[2] === "get-latest-raw-output") {
+  process.stdout.write(process.env.STUB_GET_LATEST_RAW_OUTPUT_STDOUT);
+}

--- a/all.sh
+++ b/all.sh
@@ -25,9 +25,8 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
   latest_raw_upload="$(mktemp)"
   prev_ref="$("${TRUNK_PATH}" check get-latest-raw-output \
     --series "${INPUT_UPLOAD_SERIES:-${GITHUB_REF_NAME}}" \
-    --token "${INPUT_TRUNK_TOKEN}" \
     "${latest_raw_upload}")"
-  if [[ ${prev_ref} =~ .*UNSPECIFIED.* ]]; then
+  if [[ ${prev_ref} =~ .*"new series".* ]]; then
     echo "${prev_ref}"
     htl_arg=""
   else
@@ -39,7 +38,6 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     --upload \
     ${htl_arg} \
     --series "${INPUT_UPLOAD_SERIES:-${GITHUB_REF_NAME}}" \
-    --token "${INPUT_TRUNK_TOKEN}" \
     ${INPUT_ARGUMENTS}
 else
   "${TRUNK_PATH}" check \


### PR DESCRIPTION
* the CLI now does not print "UNSPECIFED" in messages when starting a new series; it only prints "Starting new series" (see trunk-io/trunk#9721)
* stop explicitly passing `--token` in the `check_all_mode: hold-the-line` path - the CLI now respects `TRUNK_TOKEN` and #142 removed the explicit passing in most paths, except for the ones in `all.sh`