### PR TITLE
fix: print error message if CLI is too old to use upload id

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -272,7 +272,7 @@ jobs:
         run: |
           cd local-action
           npm install
-          ./action_tests/assert.js all-hold-the-line-existing-series
+          ./action_tests/assert.js all-hold-the-line-old-cli-version
 
   all-hold-the-line-no-upload-id:
     runs-on: ubuntu-latest

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -235,6 +235,44 @@ jobs:
           npm install
           ./action_tests/assert.js all-hold-the-line-existing-series
 
+  all-hold-the-line-old-cli-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: |
+          ./local-action/action_tests/setup.sh src-repo repo-under-test
+          cd repo-under-test
+          echo "EXPECTED_UPSTREAM=$(git rev-parse main^)" >>$GITHUB_ENV
+
+      - name: Run trunk-action
+        shell: bash
+        run: |
+          cd repo-under-test
+          ../local-action/all.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_ALL_MODE: hold-the-line
+          INPUT_DEBUG: ""
+          INPUT_TRUNK_TOKEN: trunk-token
+          INPUT_UPLOAD_SERIES: series-name
+          INPUT_UPLOAD_ID: test-upload-id
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+          TRUNK_CLI_VERSION: 1.12.0
+          STUB_GET_LATEST_RAW_OUTPUT_STDOUT: ${{ env.EXPECTED_UPSTREAM }}
+
+      - name: Assert CLI calls
+        shell: bash
+        run: |
+          cd local-action
+          npm install
+          ./action_tests/assert.js all-hold-the-line-existing-series
+
   all-hold-the-line-no-upload-id:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -265,6 +265,7 @@ jobs:
           TRUNK_PATH: ../local-action/action_tests/stub.js
           TRUNK_CLI_VERSION: 1.12.0
           STUB_GET_LATEST_RAW_OUTPUT_STDOUT: ${{ env.EXPECTED_UPSTREAM }}
+        continue-on-error: true
 
       - name: Assert CLI calls
         shell: bash

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -116,6 +116,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       "series-name",
     ],
   ],
+  // the stub hands back an old version in env.TRUNK_CLI_VERSION for this test
   "all-hold-the-line-old-cli-version": () => [
     ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],
     ["trunk", "version"],

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -89,6 +89,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
   ],
   "all-hold-the-line-new-series": () => [
     ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],
+    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -102,6 +103,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
   ],
   "all-hold-the-line-existing-series": () => [
     ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],
+    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -113,6 +115,10 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       "--series",
       "series-name",
     ],
+  ],
+  "all-hold-the-line-old-cli-version": () => [
+    ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],
+    ["trunk", "version"],
   ],
   "all-hold-the-line-no-upload-id": () => [
     ["trunk", "check", "get-latest-raw-output", "--series", "series-name", getHtlFactoriesPath()],

--- a/action_tests/stub.js
+++ b/action_tests/stub.js
@@ -13,7 +13,7 @@ const getArgv = () => {
     JSON.stringify({
       error: "Failed to sanitize argv",
       argv: process.argv,
-    })
+    }),
   );
   fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
   return process.argv;
@@ -28,4 +28,8 @@ fs.appendFileSync(process.env.TRUNK_STUB_LOGS, "\n");
 
 if (argv[1] === "check" && argv[2] === "get-latest-raw-output") {
   process.stdout.write(process.env.STUB_GET_LATEST_RAW_OUTPUT_STDOUT);
+}
+
+if (argv[1] === "version") {
+  process.stdout.write(process.env.TRUNK_CLI_VERSION || "99.99.99");
 }

--- a/all.sh
+++ b/all.sh
@@ -38,6 +38,7 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
   if [[ -n ${INPUT_UPLOAD_ID-} ]]; then # if upload ID unset, skip it instead of erroring
     upload_id_arg="--upload-id ${INPUT_UPLOAD_ID}"
     trunk_version="$(${TRUNK_PATH} version)"
+    echo ${trunk_version}
     # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
     if [[ "$(printf "%s\n%s\n" "${MINIMUM_UPLOAD_ID_VERSION}" "${trunk_version}" |
       sort --version-sort |

--- a/all.sh
+++ b/all.sh
@@ -15,6 +15,8 @@ fetch() {
     "$@"
 }
 
+MINIMUM_UPLOAD_ID_VERSION=1.12.3
+
 if [[ -z ${INPUT_TRUNK_TOKEN} ]]; then
   "${TRUNK_PATH}" check \
     --ci \
@@ -35,6 +37,15 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
   fi
   if [[ -n ${INPUT_UPLOAD_ID-} ]]; then # if upload ID unset, skip it instead of erroring
     upload_id_arg="--upload-id ${INPUT_UPLOAD_ID}"
+    trunk_version="$(${TRUNK_PATH} version)"
+    # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
+    if [[ "$(printf "%s\n%s\n" "${MINIMUM_UPLOAD_ID_VERSION}" "${trunk_version}" |
+      sort --version-sort |
+      head -n 1)" == "${MINIMUM_UPLOAD_ID_VERSION}"* ]]; then
+      echo "::error::Please update your CLI to ${MINIMUM_UPLOAD_ID_VERSION} or higher."
+      exit 1
+    fi
+    # trunk-ignore-end(shellcheck/SC2312)
   else
     upload_id_arg=""
   fi

--- a/all.sh
+++ b/all.sh
@@ -42,7 +42,7 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
     if [[ "$(printf "%s\n%s\n" "${MINIMUM_UPLOAD_ID_VERSION}" "${trunk_version}" |
       sort --version-sort |
       head -n 1)" == "${trunk_version}"* ]]; then
-      echo "::error::Please update your CLI to ${MINIMUM_UPLOAD_ID_VERSION} or higher."
+      echo "::error::Please update your CLI to ${MINIMUM_UPLOAD_ID_VERSION} or higher (current version ${trunk_version})."
       exit 1
     fi
     # trunk-ignore-end(shellcheck/SC2312)

--- a/all.sh
+++ b/all.sh
@@ -38,11 +38,10 @@ elif [[ ${INPUT_CHECK_ALL_MODE} == "hold-the-line" ]]; then
   if [[ -n ${INPUT_UPLOAD_ID-} ]]; then # if upload ID unset, skip it instead of erroring
     upload_id_arg="--upload-id ${INPUT_UPLOAD_ID}"
     trunk_version="$(${TRUNK_PATH} version)"
-    echo ${trunk_version}
     # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
     if [[ "$(printf "%s\n%s\n" "${MINIMUM_UPLOAD_ID_VERSION}" "${trunk_version}" |
       sort --version-sort |
-      head -n 1)" == "${MINIMUM_UPLOAD_ID_VERSION}"* ]]; then
+      head -n 1)" == "${trunk_version}"* ]]; then
       echo "::error::Please update your CLI to ${MINIMUM_UPLOAD_ID_VERSION} or higher."
       exit 1
     fi


### PR DESCRIPTION
Currently, if a user kicks off a workflow in a repo that already has a trunk.yaml that specifies a CLI version < 1.12.3, it will fail when tries to use `--upload-id`. This PR adds a check for this, and prints an error message if the CLI is too old.