### PR TITLE
add test for cli version for INPUT_CHECK_RUN_ID in action

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -8,7 +8,7 @@ env:
   TRUNK_STUB_LOGS: /tmp/trunk-stub-logs.json
 
 jobs:
-  trunk_merge:
+  trunk-merge:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,6 +41,75 @@ jobs:
           cd local-action
           npm install
           ./action_tests/assert.js trunk-merge
+
+  trunk-merge-annotate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+
+      - name: Run trunk-action
+        shell: bash
+        run: |
+          cd repo-under-test
+          git checkout trunk-merge/of-feature-branch
+          echo "EXPECTED_UPSTREAM=$(git rev-parse trunk-merge/of-feature-branch^1)" >>$GITHUB_ENV
+          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse trunk-merge/of-feature-branch^2)" >>$GITHUB_ENV
+          ../local-action/trunk_merge.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_RUN_ID: "8675309"
+          INPUT_DEBUG: ""
+          INPUT_LABEL: ""
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+
+      - name: Assert CLI calls
+        shell: bash
+        run: |
+          cd local-action
+          npm install
+          ./action_tests/assert.js trunk-merge-annotate
+
+  trunk-merge-annotate-old-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+
+      - name: Run trunk-action
+        shell: bash
+        run: |
+          cd repo-under-test
+          git checkout trunk-merge/of-feature-branch
+          echo "EXPECTED_UPSTREAM=$(git rev-parse trunk-merge/of-feature-branch^1)" >>$GITHUB_ENV
+          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse trunk-merge/of-feature-branch^2)" >>$GITHUB_ENV
+          ../local-action/trunk_merge.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_RUN_ID: "8675309"
+          INPUT_DEBUG: ""
+          INPUT_LABEL: ""
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+          TRUNK_CLI_VERSION: 1.6.0
+
+      - name: Assert CLI calls
+        shell: bash
+        run: |
+          cd local-action
+          npm install
+          ./action_tests/assert.js trunk-merge-annotate-old-cli
 
   pull-request-trunk-annotate:
     runs-on: ubuntu-latest
@@ -81,6 +150,48 @@ jobs:
           cd local-action
           npm install
           ./action_tests/assert.js pull-request-trunk-annotate
+
+  pull-request-trunk-annotate-old-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
+
+      - name: Run trunk-action
+        shell: bash
+        run: |
+          cd repo-under-test
+          git checkout feature-branch
+          export GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=$(git rev-parse feature-branch)
+          export GITHUB_EVENT_PULL_REQUEST_BASE_SHA=$(git rev-parse main)
+          echo "EXPECTED_UPSTREAM=${GITHUB_EVENT_PULL_REQUEST_BASE_SHA}" >>$GITHUB_ENV
+          echo "EXPECTED_GITHUB_COMMIT=${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA}" >>$GITHUB_ENV
+          ../local-action/pull_request.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_RUN_ID: "8675309"
+          INPUT_DEBUG: ""
+          INPUT_LABEL: ""
+          INPUT_SAVE_ANNOTATIONS: ""
+          INPUT_GITHUB_REF_NAME: feature_branch
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: "1337"
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+          INPUT_AUTOFIX_AND_PUSH: ""
+          TRUNK_CLI_VERSION: 1.6.0
+        continue-on-error: true
+
+      - name: Assert CLI calls
+        shell: bash
+        run: |
+          cd local-action
+          npm install
+          ./action_tests/assert.js pull-request-trunk-annotate-old-cli
 
   pull-request-github-annotate-file:
     runs-on: ubuntu-latest

--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -103,6 +103,7 @@ jobs:
           INPUT_LABEL: ""
           TRUNK_PATH: ../local-action/action_tests/stub.js
           TRUNK_CLI_VERSION: 1.6.0
+        continue-on-error: true
 
       - name: Assert CLI calls
         shell: bash

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -62,6 +62,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
   ],
   "trunk-merge-annotate-old-cli": () => [["trunk", "version"]],
   "pull-request-trunk-annotate": () => [
+    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -143,6 +144,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
     ["trunk", "check", "--all", "--upload", "--series", "series-name"],
   ],
   "pull-request-autofix": () => [
+    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -156,6 +158,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
   "pull-request-payload": () => [
     ["trunk", "version"],
     ["trunk", "init"],
+    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -172,6 +175,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
   "trunk-merge-payload": () => [
     ["trunk", "version"],
     ["trunk", "init"],
+    ["trunk", "version"],
     [
       "trunk",
       "check",

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -45,6 +45,22 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       "",
     ],
   ],
+  "trunk-merge-annotate": () => [
+    ["trunk", "version"],
+    [
+      "trunk",
+      "check",
+      "--ci",
+      "--upstream",
+      process.env.EXPECTED_UPSTREAM,
+      "--github-commit",
+      process.env.EXPECTED_GITHUB_COMMIT,
+      "--github-label",
+      "",
+      "--trunk-annotate=8675309",
+    ],
+  ],
+  "trunk-merge-annotate-old-cli": () => [["trunk", "version"]],
   "pull-request-trunk-annotate": () => [
     [
       "trunk",
@@ -59,6 +75,7 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       "--trunk-annotate=8675309",
     ],
   ],
+  "pull-request-trunk-annotate-old-cli": () => [["trunk", "version"]],
   "pull-request-github-annotate-file": () => [
     [
       "trunk",

--- a/trunk_merge.sh
+++ b/trunk_merge.sh
@@ -15,6 +15,8 @@ fetch() {
     "$@"
 }
 
+MINIMUM_CHECK_RUN_ID_VERSION=1.7.0
+
 head_sha=$(git rev-parse HEAD)
 fetch --depth=2 origin "${head_sha}"
 upstream=$(git rev-parse HEAD^1)
@@ -22,6 +24,15 @@ git_commit=$(git rev-parse HEAD^2)
 echo "Detected merge queue commit, using HEAD^1 (${upstream}) as upstream and HEAD^2 (${git_commit}) as github commit"
 
 if [[ -n ${INPUT_CHECK_RUN_ID} ]]; then
+  trunk_version="$(${TRUNK_PATH} version)"
+  # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
+  if [[ "$(printf "%s\n%s\n" "${MINIMUM_CHECK_RUN_ID_VERSION}" "${trunk_version}" |
+    sort --version-sort |
+    head -n 1)" == "${trunk_version}"* ]]; then
+    echo "::error::Please update your CLI to ${MINIMUM_CHECK_RUN_ID_VERSION} or higher (current version ${trunk_version})."
+    exit 1
+  fi
+  # trunk-ignore-end(shellcheck/SC2312)
   annotation_argument=--trunk-annotate=${INPUT_CHECK_RUN_ID}
 else
   annotation_argument=""


### PR DESCRIPTION
Adds a check similar to #171, but for `--trunk-annotate`.

CLI version 1.7.0 is the earliest prod CLI version after [trunk#7540](https://github.com/trunk-io/trunk/pull/7540).