### PR TITLE
fix: install latest node if setup-node fails

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -108,7 +108,7 @@ jobs:
           - repo: prawn-test-staging-rw/setup-node-test
             ref: main
             post-init: |
-              if [ $FAILED_NODE_INSTALL != "true" ]; then
+              if [ ${FAILED_NODE_INSTALL} != "true" ]; then
                 echo "::error::Initial setup node didn't fail"
                 exit 1
               fi

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -64,6 +64,14 @@ jobs:
             post-init: |
               ${TRUNK_PATH} check enable eslint
 
+          - repo: prawn-test-staging-rw/setup-node-test
+            ref: main
+            post-init: |
+              if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
+                echo "::error::Initial setup node didn't fail"
+                exit 1
+              fi
+
           - repo: replayio/devtools
             ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac
             description: (has trunk.yaml)
@@ -104,14 +112,6 @@ jobs:
 
           - repo: trunk-io/plugins
             ref: main
-
-          - repo: prawn-test-staging-rw/setup-node-test
-            ref: main
-            post-init: |
-              if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
-                echo "::error::Initial setup node didn't fail"
-                exit 1
-              fi
 
           # fails because pnpm version is too new
 

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -105,6 +105,9 @@ jobs:
           - repo: trunk-io/plugins
             ref: main
 
+          - repo: trunk-io/trunk-action
+            ref: main
+
           # fails because pnpm version is too new
 
           # - repo: vuejs/core

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -105,7 +105,7 @@ jobs:
           - repo: trunk-io/plugins
             ref: main
 
-          - repo: trunk-io/setup-node-test
+          - repo: prawn-test-staging-rw/setup-node-test
             ref: main
             post-init: |
               if [ $FAILED_NODE_INSTALL != "true" ]; then

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -105,8 +105,13 @@ jobs:
           - repo: trunk-io/plugins
             ref: main
 
-          - repo: trunk-io/trunk-action
+          - repo: trunk-io/setup-node-test
             ref: main
+            post-init: |
+              if [ $FAILED_NODE_INSTALL != "true" ]; then
+                echo "::error::Initial setup node didn't fail"
+                exit 1
+              fi
 
           # fails because pnpm version is too new
 

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -108,7 +108,7 @@ jobs:
           - repo: prawn-test-staging-rw/setup-node-test
             ref: main
             post-init: |
-              if [ ${FAILED_NODE_INSTALL} != "true" ]; then
+              if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
                 echo "::error::Initial setup node didn't fail"
                 exit 1
               fi

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "chai": "^4.3.7"
+  },
+  "engines": {
+    "node": "20.6.1"
   }
 }

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -88,10 +88,12 @@ runs:
       if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       shell: bash
       run: |
-        echo "::warning::Failed to install specified node version - installing latest node instead."
-        cat >>$GITHUB_ENV <<EOF
+        if ! command -v node >/dev/null; then
+          echo "::warning::Failed to install specified node version - installing latest node instead."
+          cat >>$GITHUB_ENV <<EOF
         FAILED_NODE_INSTALL=true
         EOF
+        fi
 
     - name: Install backup node version
       if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE && env.FAILED_NODE_INSTALL == 'true'

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -90,9 +90,7 @@ runs:
       run: |
         if ! command -v node >/dev/null; then
           echo "::warning::Failed to install specified node version - installing latest node instead."
-          cat >>$GITHUB_ENV <<EOF
-        FAILED_NODE_INSTALL=true
-        EOF
+          echo "FAILED_NODE_INSTALL=true" >>$GITHUB_ENV
         fi
 
     - name: Install backup node version

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -78,6 +78,7 @@ runs:
         version: latest
 
     - name: Install Node dependencies
+      id: setup_node
       if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       uses: actions/setup-node@v3
       with:
@@ -88,13 +89,18 @@ runs:
       if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       shell: bash
       run: |
+        if [ ${{ steps.setup_node.outcome }} == "success" ]; then
+          exit 0
+        fi
+        echo "::warning::Failed to install specified node version."
+        echo "FAILED_NODE_INSTALL=true" >>$GITHUB_ENV
         if ! command -v node >/dev/null; then
-          echo "::warning::Failed to install specified node version - installing latest node instead."
-          echo "FAILED_NODE_INSTALL=true" >>$GITHUB_ENV
+          echo "::warning::No existing node install detected - installing latest node instead."
+          echo "INSTALL_LATEST_NODE=true" >>$GITHUB_ENV
         fi
 
     - name: Install backup node version
-      if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE && env.FAILED_NODE_INSTALL == 'true'
+      if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE && env.INSTALL_LATEST_NODE == 'true'
       uses: actions/setup-node@v3
       with:
         node-version-file: latest

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -82,6 +82,24 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: ${{ env.NODE_VERSION_FILE }}
+      continue-on-error: true
+
+    - name: Check for node installation
+      if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
+      shell: bash
+      run: |
+        if ! command -v node >/dev/null; then
+          echo "::warning::Failed to install specified node version - installing latest node instead."
+          cat >>$GITHUB_ENV <<EOF
+        FAILED_NODE_INSTALL=true
+        EOF
+        fi
+
+    - name: Install backup node version
+      if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE && env.FAILED_NODE_INSTALL == 'true'
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: latest
 
     - name: Cache node_modules
       if: inputs.cache-key && env.PACKAGE_MANAGER

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -88,12 +88,10 @@ runs:
       if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE
       shell: bash
       run: |
-        if ! command -v node >/dev/null; then
-          echo "::warning::Failed to install specified node version - installing latest node instead."
-          cat >>$GITHUB_ENV <<EOF
+        echo "::warning::Failed to install specified node version - installing latest node instead."
+        cat >>$GITHUB_ENV <<EOF
         FAILED_NODE_INSTALL=true
         EOF
-        fi
 
     - name: Install backup node version
       if: env.PACKAGE_MANAGER && env.NODE_VERSION_FILE && env.FAILED_NODE_INSTALL == 'true'


### PR DESCRIPTION
Continues if the setup-node action fails to install, and then installs latest node if there is no node version installed. Judging by [this website](https://node.green/) showing note compatibilities, node is almost entirely backwards compatible, which is why I went with the latest version rather than e.g. node 20.

Additionally, adds a node version to the package.json so that this PR can merge - the v1 action version still chokes when not finding the node version.

This is tested by adding the trunk-action repo to the [repo tests](https://github.com/trunk-io/trunk-action/actions/runs/6156480974/job/16705376207?pr=186), which does not have a node version in main. However, the runners have node installed, so the action doesn't attempt to install a default version - I'm not sure if there's a better way to test that/if it's worth it.