### PR TITLE
chore: jbeder/yaml-cpp repo_test has been failing for a while

### DIFF
--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -44,6 +44,7 @@ jobs:
               sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
               cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
               ${TRUNK_PATH} check enable clang-tidy
+              ${TRUNK_PATH} check disable markdownlint
 
           - repo: pallets/flask
             ref: 4bcd4be6b7d69521115ef695a379361732bcaea6

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -44,6 +44,7 @@ jobs:
               sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
               cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
               ${TRUNK_PATH} check enable clang-tidy
+              # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
               ${TRUNK_PATH} check disable markdownlint
 
           - repo: pallets/flask


### PR DESCRIPTION
But we only care about the clang-tidy integration, not the markdownlint integration.