### PR TITLE
feat: add 'lowercase-title' option to upgrade action

### DIFF
--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -52,6 +52,11 @@ inputs:
     required: false
     default: .trunk
 
+  lowercase-title:
+    description: A boolean to decide if the PR and commit message title should be in lowercase
+    required: false
+    default: false
+
 runs:
   using: composite
   steps:
@@ -95,6 +100,7 @@ runs:
         ${{ github.action_path }}/upgrade.sh
       env:
         UPGRADE_ARGUMENTS: ${{ inputs.arguments }}
+        LOWERCASE_TITLE: ${{ inputs.lowercase-title }}
 
     - name: Cleanup temporary files
       if: always()

--- a/upgrade/upgrade.sh
+++ b/upgrade/upgrade.sh
@@ -21,6 +21,10 @@ if [[ ${trimmed_upgrade_output} == *"cli upgrade"* ]]; then
   title_message="Upgrade trunk to ${new_cli_version}"
 fi
 
+if [[ ${LOWERCASE_TITLE} == "true" ]]; then
+  title_message=$(echo "${title_message}" | tr '[:upper:]' '[:lower:]')
+fi
+
 # Step 3: Prepare for pull request creation action.
 # Avoid triggering a git-hook, and avoid resetting git hook config via daemon
 ${TRUNK_PATH} daemon shutdown


### PR DESCRIPTION
Adds 'lowercase-title' option to the 'trunk-action/upgrade' action. Specifying the option converts the PR / commit title "Upgrade trunk" to lowercase, i.e. "upgrade trunk"

Example usage:

  - uses: trunk-io/trunk-action/upgrade@v1 with: prefix: "chore(deps): " lowercase-title: true

This change makes it possible to use the trunk upgrade action in a way that conforms to the commitlint '@commitlint/config-conventional' configuration which specifies that commit message subject must not be sentence-case, start-case, pascal-case, upper-case. With the default commit message title "Upgrade trunk" and `prefix: "chore(deps): "` the following error is emitted by commitlint using `config-conventional`:

  ⧗   input: chore(deps): Upgrade trunk to 1.19.0
  ✖   subject must not be sentence-case, start-case, pascal-case, upper-case [subject-case]

  ✖   found 1 problems, 0 warnings
  ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint