### PR TITLE
fix: add default `chore: ` prefix to upgrade action

### DIFF
--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -17,6 +17,7 @@ inputs:
   prefix:
     description: Prefix to be added in the PR title
     required: false
+    default: "chore: "
 
   arguments:
     description: Extra arguments to pass to trunk upgrade


### PR DESCRIPTION
Currently upgrade actions doesn't use semantic PR title. This can cause problems for orgs who rely on conventional commit or use tools like semantic PR causing checks to fail. This PR adds a default prefix value of `chore: ` to PR title.