### PR TITLE
Update actions/cache@v3 to actions/cache@v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -249,7 +249,7 @@ runs:
 
     - name: Cache Linters/Formatters
       if: env.TRUNK_CHECK_MODE != 'none' && env.INPUT_CACHE == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.INPUT_CACHE_PATH }}
         key: ${{ env.INPUT_CACHE_KEY }}


### PR DESCRIPTION
This will silence a warning about using Node 16, in favor of using Node 20.