### PR TITLE
feat: continue on node package install failure

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,27 +7,27 @@ concurrency:
 permissions: read-all
 
 jobs:
-  # trunk_check:
-  #   name: Trunk Check Runner
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     checks: write # For trunk to post annotations
+  trunk_check:
+    name: Trunk Check Runner
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write # For trunk to post annotations
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-  #     - name: Trunk Check
-  #       uses: ./ # external users, use: trunk-io/trunk-action@v1
+      - name: Trunk Check
+        uses: ./ # external users, use: trunk-io/trunk-action@v1
 
-  # action_tests:
-  #   name: Action tests
-  #   uses: ./.github/workflows/action_tests.yaml
+  action_tests:
+    name: Action tests
+    uses: ./.github/workflows/action_tests.yaml
 
   repo_tests:
     name: Repository tests
     uses: ./.github/workflows/repo_tests.yaml
 
-  # docker_repo_tests:
-  #   name: Repository tests (docker)
-  #   uses: ./.github/workflows/docker_repo_tests.yaml
+  docker_repo_tests:
+    name: Repository tests (docker)
+    uses: ./.github/workflows/docker_repo_tests.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,27 +7,27 @@ concurrency:
 permissions: read-all
 
 jobs:
-  trunk_check:
-    name: Trunk Check Runner
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write # For trunk to post annotations
+  # trunk_check:
+  #   name: Trunk Check Runner
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     checks: write # For trunk to post annotations
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Trunk Check
-        uses: ./ # external users, use: trunk-io/trunk-action@v1
+  #     - name: Trunk Check
+  #       uses: ./ # external users, use: trunk-io/trunk-action@v1
 
-  action_tests:
-    name: Action tests
-    uses: ./.github/workflows/action_tests.yaml
+  # action_tests:
+  #   name: Action tests
+  #   uses: ./.github/workflows/action_tests.yaml
 
   repo_tests:
     name: Repository tests
     uses: ./.github/workflows/repo_tests.yaml
 
-  docker_repo_tests:
-    name: Repository tests (docker)
-    uses: ./.github/workflows/docker_repo_tests.yaml
+  # docker_repo_tests:
+  #   name: Repository tests (docker)
+  #   uses: ./.github/workflows/docker_repo_tests.yaml

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -35,7 +35,8 @@ jobs:
             description: (compile-commands.json)
             post-init: |
               # black complains about py2 code
-              ${TRUNK_PATH} check disable black
+              # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
+              ${TRUNK_PATH} check disable black markdownlint
               mkdir build
               cd build
               cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -44,8 +45,6 @@ jobs:
               sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
               cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
               ${TRUNK_PATH} check enable clang-tidy
-              # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
-              ${TRUNK_PATH} check disable markdownlint
 
           - repo: pallets/flask
             ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
@@ -112,10 +111,7 @@ jobs:
             description: (has trunk.yaml)
             post-init: |
               # all of these linters have failures
-              ${TRUNK_PATH} check disable svgo
-              ${TRUNK_PATH} check disable golangci-lint
-              ${TRUNK_PATH} check disable prettier
-              ${TRUNK_PATH} check disable oxipng
+              ${TRUNK_PATH} check disable svgo golangci-lint prettier oxipng
 
           - repo: shopify/draggable
             ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -22,58 +22,58 @@ jobs:
           #   * the repo and its dependency closure should be fast to set up, since we trigger
           #     this workflow on PRs
           #
-          - repo: highlightjs/highlight.js
-            ref: 4f9cd3bffb6bc55c9e2c4252c7b733a219880151
-            description: (uses npm)
-            post-init: |
-              # terrascan scans dockerfile.js (a JS file for parsing dockerfiles) as a dockerfile itself
-              echo "src/languages/dockerfile.js" >> .gitignore
-              cp local-action/repo_tests/highlightjs.yaml .trunk/user.yaml
+          # - repo: highlightjs/highlight.js
+          #   ref: 4f9cd3bffb6bc55c9e2c4252c7b733a219880151
+          #   description: (uses npm)
+          #   post-init: |
+          #     # terrascan scans dockerfile.js (a JS file for parsing dockerfiles) as a dockerfile itself
+          #     echo "src/languages/dockerfile.js" >> .gitignore
+          #     cp local-action/repo_tests/highlightjs.yaml .trunk/user.yaml
 
-          - repo: jbeder/yaml-cpp
-            ref: 0e6e28d1a38224fc8172fae0109ea7f673c096db
-            description: (compile-commands.json)
-            post-init: |
-              # black complains about py2 code
-              ${TRUNK_PATH} check disable black
-              mkdir build
-              cd build
-              cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-              cd ..
-              ln -s build/compile_commands.json
-              sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
-              cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
-              ${TRUNK_PATH} check enable clang-tidy
-              # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
-              ${TRUNK_PATH} check disable markdownlint
+          # - repo: jbeder/yaml-cpp
+          #   ref: 0e6e28d1a38224fc8172fae0109ea7f673c096db
+          #   description: (compile-commands.json)
+          #   post-init: |
+          #     # black complains about py2 code
+          #     ${TRUNK_PATH} check disable black
+          #     mkdir build
+          #     cd build
+          #     cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          #     cd ..
+          #     ln -s build/compile_commands.json
+          #     sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
+          #     cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
+          #     ${TRUNK_PATH} check enable clang-tidy
+          #     # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
+          #     ${TRUNK_PATH} check disable markdownlint
 
-          - repo: pallets/flask
-            ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
-            post-init: |
-              # prettier chokes on this malformed html file
-              echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
-              cp local-action/repo_tests/flask.yaml .trunk/user.yaml
+          # - repo: pallets/flask
+          #   ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
+          #   post-init: |
+          #     # prettier chokes on this malformed html file
+          #     echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
+          #     cp local-action/repo_tests/flask.yaml .trunk/user.yaml
 
-          - repo: postcss/postcss
-            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
-            description: (uses pnpm)
-            post-init: |
-              ${TRUNK_PATH} check enable eslint
+          # - repo: postcss/postcss
+          #   ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
+          #   description: (uses pnpm)
+          #   post-init: |
+          #     ${TRUNK_PATH} check enable eslint
 
-          - repo: postcss/postcss
-            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
-            description: (compat test for cli 1.0.0)
-            post-init: |
-              ${TRUNK_PATH} check enable eslint
+          # - repo: postcss/postcss
+          #   ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
+          #   description: (compat test for cli 1.0.0)
+          #   post-init: |
+          #     ${TRUNK_PATH} check enable eslint
 
-          - repo: prawn-test-staging-rw/setup-node-test
-            ref: main
-            post-init: |
-              if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
-                echo "::error::Initial setup node didn't fail"
-                exit 1
-              fi
-            description: (test for setup-node)
+          # - repo: prawn-test-staging-rw/setup-node-test
+          #   ref: main
+          #   post-init: |
+          #     if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
+          #       echo "::error::Initial setup node didn't fail"
+          #       exit 1
+          #     fi
+          #   description: (test for setup-node)
 
           - repo: prawn-test-staging-rw/node-packages-failure-test
             ref: main
@@ -82,6 +82,9 @@ jobs:
                 echo "::error::Node package install didn't fail"
                 exit 1
               fi
+              echo "====="
+              ${TRUNK_PATH} check list --color=false
+              echo "====="
               if ! grep -q "✔ eslint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::eslint not disabled"
                 exit 1
@@ -103,35 +106,35 @@ jobs:
               ${TRUNK_PATH} upgrade
             trunk-path: node_modules/.bin/trunk
 
-          - repo: sass/sass
-            ref: 225e176115211387e014d97ae0076d94de3152a1
-            description: (uses npm)
+          # - repo: sass/sass
+          #   ref: 225e176115211387e014d97ae0076d94de3152a1
+          #   description: (uses npm)
 
-          - repo: sheldonhull/sheldonhull.hugo
-            ref: 0810b7219c6681931bbf727cd9fe81693b414b60
-            description: (has trunk.yaml)
-            post-init: |
-              # all of these linters have failures
-              ${TRUNK_PATH} check disable svgo
-              ${TRUNK_PATH} check disable golangci-lint
-              ${TRUNK_PATH} check disable prettier
-              ${TRUNK_PATH} check disable oxipng
+          # - repo: sheldonhull/sheldonhull.hugo
+          #   ref: 0810b7219c6681931bbf727cd9fe81693b414b60
+          #   description: (has trunk.yaml)
+          #   post-init: |
+          #     # all of these linters have failures
+          #     ${TRUNK_PATH} check disable svgo
+          #     ${TRUNK_PATH} check disable golangci-lint
+          #     ${TRUNK_PATH} check disable prettier
+          #     ${TRUNK_PATH} check disable oxipng
 
-          - repo: shopify/draggable
-            ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
-            description: (uses yarn)
+          # - repo: shopify/draggable
+          #   ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
+          #   description: (uses yarn)
 
-          - repo: terraform-linters/tflint
-            ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
-            post-init: |
-              # golangci-lint needs us to init with a newer go runtime
-              ${TRUNK_PATH} check disable golangci-lint
-              # tfsec and terrascan scan these malformed test files and error
-              echo "integrationtest/" >> .gitignore
-              echo "terraform/test-fixtures" >> .gitignore
+          # - repo: terraform-linters/tflint
+          #   ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
+          #   post-init: |
+          #     # golangci-lint needs us to init with a newer go runtime
+          #     ${TRUNK_PATH} check disable golangci-lint
+          #     # tfsec and terrascan scan these malformed test files and error
+          #     echo "integrationtest/" >> .gitignore
+          #     echo "terraform/test-fixtures" >> .gitignore
 
-          - repo: trunk-io/plugins
-            ref: main
+          # - repo: trunk-io/plugins
+          #   ref: main
 
           # fails because pnpm version is too new
 
@@ -142,12 +145,12 @@ jobs:
           #     # svgo gets confused by JS module loading
           #     ${TRUNK_PATH} check disable svgo
 
-          - repo: z-shell/wiki
-            ref: d6d8b5da28c170b3b226705795412497f7059681
-            description: (has trunk.yaml)
-            post-init: |
-              # stylelint is exiting with error code -11
-              ${TRUNK_PATH} check disable stylelint
+          # - repo: z-shell/wiki
+          #   ref: d6d8b5da28c170b3b226705795412497f7059681
+          #   description: (has trunk.yaml)
+          #   post-init: |
+          #     # stylelint is exiting with error code -11
+          #     ${TRUNK_PATH} check disable stylelint
 
     steps:
       - name: Checkout ${{ matrix.repo }}

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -82,11 +82,11 @@ jobs:
                 echo "::error::Node package install didn't fail"
                 exit 1
               fi
-              if ! trunk check list --color=false | grep -q "✔ eslint"; then
+              if ! grep -q "✔ eslint" <(trunk check list --color=false); then
                 echo "::error::eslint not disabled"
                 exit 1
               fi
-              if ! trunk check list --color=false | grep -q "✔ stylelint"; then
+              if ! grep -q "✔ stylelint" <(trunk check list --color=false); then
                 echo "::error::stylelint not disabled"
                 exit 1
               fi

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -82,11 +82,11 @@ jobs:
                 echo "::error::Node package install didn't fail"
                 exit 1
               fi
-              if ! grep -q "✔ eslint" <(trunk check list --color=false); then
+              if ! grep -q "✔ eslint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::eslint not disabled"
                 exit 1
               fi
-              if ! grep -q "✔ stylelint" <(trunk check list --color=false); then
+              if ! grep -q "✔ stylelint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::stylelint not disabled"
                 exit 1
               fi

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -85,11 +85,11 @@ jobs:
               echo "====="
               ${TRUNK_PATH} check list --color=false
               echo "====="
-              if ! grep -q "✔ eslint" <(${TRUNK_PATH} check list --color=false); then
+              if grep -q "✔ eslint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::eslint not disabled"
                 exit 1
               fi
-              if ! grep -q "✔ stylelint" <(${TRUNK_PATH} check list --color=false); then
+              if grep -q "✔ stylelint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::stylelint not disabled"
                 exit 1
               fi

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -82,8 +82,6 @@ jobs:
                 echo "::error::Node package install didn't fail"
                 exit 1
               fi
-              echo "====="
-              echo "====="
               if grep -q "✔ eslint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::eslint not disabled"
                 exit 1

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -75,6 +75,15 @@ jobs:
               fi
             description: (test for setup-node)
 
+          - repo: prawn-test-staging-rw/node-packages-failure-test
+            ref: main
+            post-init: |
+              if [ "${FAILED_NODE_PACKAGE_INSTALL}" != "true" ]; then
+                echo "::error::Node package install didn't fail"
+                exit 1
+              fi
+            description: (test for continuing on node package install failure)
+
           - repo: replayio/devtools
             ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac
             description: (has trunk.yaml)

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -22,58 +22,58 @@ jobs:
           #   * the repo and its dependency closure should be fast to set up, since we trigger
           #     this workflow on PRs
           #
-          # - repo: highlightjs/highlight.js
-          #   ref: 4f9cd3bffb6bc55c9e2c4252c7b733a219880151
-          #   description: (uses npm)
-          #   post-init: |
-          #     # terrascan scans dockerfile.js (a JS file for parsing dockerfiles) as a dockerfile itself
-          #     echo "src/languages/dockerfile.js" >> .gitignore
-          #     cp local-action/repo_tests/highlightjs.yaml .trunk/user.yaml
+          - repo: highlightjs/highlight.js
+            ref: 4f9cd3bffb6bc55c9e2c4252c7b733a219880151
+            description: (uses npm)
+            post-init: |
+              # terrascan scans dockerfile.js (a JS file for parsing dockerfiles) as a dockerfile itself
+              echo "src/languages/dockerfile.js" >> .gitignore
+              cp local-action/repo_tests/highlightjs.yaml .trunk/user.yaml
 
-          # - repo: jbeder/yaml-cpp
-          #   ref: 0e6e28d1a38224fc8172fae0109ea7f673c096db
-          #   description: (compile-commands.json)
-          #   post-init: |
-          #     # black complains about py2 code
-          #     ${TRUNK_PATH} check disable black
-          #     mkdir build
-          #     cd build
-          #     cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          #     cd ..
-          #     ln -s build/compile_commands.json
-          #     sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
-          #     cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
-          #     ${TRUNK_PATH} check enable clang-tidy
-          #     # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
-          #     ${TRUNK_PATH} check disable markdownlint
+          - repo: jbeder/yaml-cpp
+            ref: 0e6e28d1a38224fc8172fae0109ea7f673c096db
+            description: (compile-commands.json)
+            post-init: |
+              # black complains about py2 code
+              ${TRUNK_PATH} check disable black
+              mkdir build
+              cd build
+              cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+              cd ..
+              ln -s build/compile_commands.json
+              sed -i "s|lint:|lint:\n  compile_commands: json|" .trunk/trunk.yaml
+              cp local-action/repo_tests/yaml_cpp.yaml .trunk/user.yaml
+              ${TRUNK_PATH} check enable clang-tidy
+              # markdownlint fails for some reason, and what we really care about anyways is clang-tidy
+              ${TRUNK_PATH} check disable markdownlint
 
-          # - repo: pallets/flask
-          #   ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
-          #   post-init: |
-          #     # prettier chokes on this malformed html file
-          #     echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
-          #     cp local-action/repo_tests/flask.yaml .trunk/user.yaml
+          - repo: pallets/flask
+            ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
+            post-init: |
+              # prettier chokes on this malformed html file
+              echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
+              cp local-action/repo_tests/flask.yaml .trunk/user.yaml
 
-          # - repo: postcss/postcss
-          #   ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
-          #   description: (uses pnpm)
-          #   post-init: |
-          #     ${TRUNK_PATH} check enable eslint
+          - repo: postcss/postcss
+            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
+            description: (uses pnpm)
+            post-init: |
+              ${TRUNK_PATH} check enable eslint
 
-          # - repo: postcss/postcss
-          #   ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
-          #   description: (compat test for cli 1.0.0)
-          #   post-init: |
-          #     ${TRUNK_PATH} check enable eslint
+          - repo: postcss/postcss
+            ref: aa9e03ea4708909631eba70500c8c0cc0708bb4e
+            description: (compat test for cli 1.0.0)
+            post-init: |
+              ${TRUNK_PATH} check enable eslint
 
-          # - repo: prawn-test-staging-rw/setup-node-test
-          #   ref: main
-          #   post-init: |
-          #     if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
-          #       echo "::error::Initial setup node didn't fail"
-          #       exit 1
-          #     fi
-          #   description: (test for setup-node)
+          - repo: prawn-test-staging-rw/setup-node-test
+            ref: main
+            post-init: |
+              if [ "${FAILED_NODE_INSTALL}" != "true" ]; then
+                echo "::error::Initial setup node didn't fail"
+                exit 1
+              fi
+            description: (test for setup-node)
 
           - repo: prawn-test-staging-rw/node-packages-failure-test
             ref: main
@@ -83,7 +83,6 @@ jobs:
                 exit 1
               fi
               echo "====="
-              ${TRUNK_PATH} check list --color=false
               echo "====="
               if grep -q "✔ eslint" <(${TRUNK_PATH} check list --color=false); then
                 echo "::error::eslint not disabled"
@@ -106,35 +105,35 @@ jobs:
               ${TRUNK_PATH} upgrade
             trunk-path: node_modules/.bin/trunk
 
-          # - repo: sass/sass
-          #   ref: 225e176115211387e014d97ae0076d94de3152a1
-          #   description: (uses npm)
+          - repo: sass/sass
+            ref: 225e176115211387e014d97ae0076d94de3152a1
+            description: (uses npm)
 
-          # - repo: sheldonhull/sheldonhull.hugo
-          #   ref: 0810b7219c6681931bbf727cd9fe81693b414b60
-          #   description: (has trunk.yaml)
-          #   post-init: |
-          #     # all of these linters have failures
-          #     ${TRUNK_PATH} check disable svgo
-          #     ${TRUNK_PATH} check disable golangci-lint
-          #     ${TRUNK_PATH} check disable prettier
-          #     ${TRUNK_PATH} check disable oxipng
+          - repo: sheldonhull/sheldonhull.hugo
+            ref: 0810b7219c6681931bbf727cd9fe81693b414b60
+            description: (has trunk.yaml)
+            post-init: |
+              # all of these linters have failures
+              ${TRUNK_PATH} check disable svgo
+              ${TRUNK_PATH} check disable golangci-lint
+              ${TRUNK_PATH} check disable prettier
+              ${TRUNK_PATH} check disable oxipng
 
-          # - repo: shopify/draggable
-          #   ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
-          #   description: (uses yarn)
+          - repo: shopify/draggable
+            ref: e6cf325a98c11b8aefbfb626b7a91b95d1c340c9
+            description: (uses yarn)
 
-          # - repo: terraform-linters/tflint
-          #   ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
-          #   post-init: |
-          #     # golangci-lint needs us to init with a newer go runtime
-          #     ${TRUNK_PATH} check disable golangci-lint
-          #     # tfsec and terrascan scan these malformed test files and error
-          #     echo "integrationtest/" >> .gitignore
-          #     echo "terraform/test-fixtures" >> .gitignore
+          - repo: terraform-linters/tflint
+            ref: 9c34a740319e2410094ca2754e5eca860f2d13f5
+            post-init: |
+              # golangci-lint needs us to init with a newer go runtime
+              ${TRUNK_PATH} check disable golangci-lint
+              # tfsec and terrascan scan these malformed test files and error
+              echo "integrationtest/" >> .gitignore
+              echo "terraform/test-fixtures" >> .gitignore
 
-          # - repo: trunk-io/plugins
-          #   ref: main
+          - repo: trunk-io/plugins
+            ref: main
 
           # fails because pnpm version is too new
 
@@ -145,12 +144,12 @@ jobs:
           #     # svgo gets confused by JS module loading
           #     ${TRUNK_PATH} check disable svgo
 
-          # - repo: z-shell/wiki
-          #   ref: d6d8b5da28c170b3b226705795412497f7059681
-          #   description: (has trunk.yaml)
-          #   post-init: |
-          #     # stylelint is exiting with error code -11
-          #     ${TRUNK_PATH} check disable stylelint
+          - repo: z-shell/wiki
+            ref: d6d8b5da28c170b3b226705795412497f7059681
+            description: (has trunk.yaml)
+            post-init: |
+              # stylelint is exiting with error code -11
+              ${TRUNK_PATH} check disable stylelint
 
     steps:
       - name: Checkout ${{ matrix.repo }}

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -82,6 +82,14 @@ jobs:
                 echo "::error::Node package install didn't fail"
                 exit 1
               fi
+              if ! trunk check list --color=false | grep -q "✔ eslint"; then
+                echo "::error::eslint not disabled"
+                exit 1
+              fi
+              if ! trunk check list --color=false | grep -q "✔ stylelint"; then
+                echo "::error::stylelint not disabled"
+                exit 1
+              fi
             description: (test for continuing on node package install failure)
 
           - repo: replayio/devtools

--- a/action.yaml
+++ b/action.yaml
@@ -223,6 +223,7 @@ runs:
       run: |
         if [ ! -e .trunk/trunk.yaml ]; then
           ${TRUNK_PATH:-trunk} init
+          echo "INITIALIZED_TRUNK=true" >>$GITHUB_ENV
         fi
 
     - name: Detect setup strategy

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -137,5 +137,4 @@ runs:
         fi
         echo "::warning::Failed to install node packages."
         echo "::warning::Disabling linters that depend on node packages."
-        ${TRUNK_PATH} check disable eslint
-        ${TRUNK_PATH} check disable stylelint
+        ${TRUNK_PATH} check disable eslint stylelint

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -115,6 +115,27 @@ runs:
           hashFiles(env.HASH_GLOB) }}
 
     - name: Install ${{ env.PACKAGE_MANAGER }} packages
+      id: install_packages
       if: env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE || env.RUN_INSTALL_NODE_PACKAGES)
       shell: bash
       run: ${{ env.INSTALL_CMD }}
+      continue-on-error: true
+
+    - name: Check for package install
+      if: env.PACKAGE_MANAGER && (env.NODE_VERSION_FILE || env.RUN_INSTALL_NODE_PACKAGES)
+      shell: bash
+      run: |
+        if [ ${{ steps.install_packages.outcome }} == "success" ]; then
+          exit 0
+        fi
+        echo "FAILED_NODE_PACKAGE_INSTALL=true" >>$GITHUB_ENV
+
+        if [[ -z "${INITIALIZED_TRUNK}" ]]; then
+          echo "::error::Failed to install node packages."
+          echo "::error::Aborting because this repo has an existing trunk.yaml file."
+          exit 1
+        fi
+        echo "::warning::Failed to install node packages."
+        echo "::warning::Disabling linters that depend on node packages."
+        ${TRUNK_PATH} check disable eslint
+        ${TRUNK_PATH} check disable stylelint


### PR DESCRIPTION
### Problem

Currently, most of our check-on-prs/check nightly failures occur while installing node packages, for a variety of reasons. Right now, this causes the check to fail, and we report that "something went wrong". Instead, we may want to disable linters that depend on node-modules (specifically, stylelint and eslint) and lint the remaining files to report our best-effort results.

Pros:
- We would report some issues, and some issues is better than no issues
- We wouldn't be erroring with a message that seems like an internal error (because for all we know right now, it could be)

Cons:
- A user could introduce a lint issue in the same PR as a breaking change to package.json and we would pass that PR
- I am pretty sure that we don't have a great way of surfacing to the user that we're disabling eslint without writing an annoying amount of boilerplate to send the data through the cli through services back to github
  - We do log this in the action logs, but that's the most visible place

### Solution

After talking with Sam about this, we figured the best solution is to disable the linters if we are auto-initing for the user, but not if the user has a trunk.yaml and therefore has deliberately opted to see ts/js issues.

### Testing

Added a repo test for [prawn-test-staging-rw/node-packages-failure-test](https://github.com/prawn-test-staging-rw/node-packages-failure-test/tree/main) that has an invalid package.json, and checks to make sure the action disables eslint and stylelint, and continues after the failure.
