### PR TITLE
fix: attempt to install specified pnpm version

### DIFF
--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -76,7 +76,7 @@ runs:
       shell: bash
       run: |
         if [ -e package.json ] && command -v jq >/dev/null; then
-          PNPM_VERSION=$(jq -r '.packageManager|split("@")[1]' package.json)
+          PNPM_VERSION=$(jq -r '.packageManager|split("@")[1]' package.json || echo "")
         fi
         if [ -z "${PNPM_VERSION}" ]; then
           PNPM_VERSION=latest

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -71,11 +71,23 @@ runs:
           echo "Could not find existing node install, skipping node package installation"
         fi
 
+    - name: Determine pnpm version
+      if: env.PACKAGE_MANAGER == 'pnpm'
+      shell: bash
+      run: |
+        if [ -e package.json ] && command -v jq >/dev/null; then
+          PNPM_VERSION=$(jq -r '.packageManager|split("@")[1]' package.json)
+        fi
+        if [ -z "${PNPM_VERSION}" ]; then
+          PNPM_VERSION=latest
+        fi
+        echo "PNPM_VERSION=${PNPM_VERSION}" >>$GITHUB_ENV
+
     - name: Install pnpm
       if: env.PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@v2
       with:
-        version: latest
+        version: ${{ env.PNPM_VERSION }}
 
     - name: Install Node dependencies
       id: setup_node


### PR DESCRIPTION
Currently, we only install the latest pnpm version, which fails if the user has specified a pnpm version under `packageManager` in their package.json. This PR changes that to attempt to parse the version out of the package.json before defaulting to latest.

The `pnpm/action-setup` action does have logic for parsing the version out of the package.json, but we cannot provide both an version and a version in the package.json, or it will fail ([source link](https://github.com/pnpm/action-setup/blob/master/src/install-pnpm/run.ts#L64)).

Tested manually, both with and without the `packageManager` field.