### PR TITLE
[feat] add timeout and ability to cat debug logs

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -419,6 +419,49 @@ jobs:
           npm install
           ./action_tests/assert.js all-hold-the-line-no-upload-id
 
+  pull_request_expect_trunk_check_timeout:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: local-action
+
+      - name: Set up test
+        shell: bash
+        run: |
+          ./local-action/action_tests/setup.sh src-repo repo-under-test
+          cd repo-under-test
+          git checkout feature-branch
+          echo "EXPECTED_UPSTREAM=$(git rev-parse feature-branch^1)" >>$GITHUB_ENV
+
+      - name: Run trunk-action
+        shell: bash
+        id: trunk-action
+        run: |
+          cd repo-under-test
+          git checkout feature-branch
+          ../local-action/pull_request.sh
+        env:
+          INPUT_ARGUMENTS: ""
+          INPUT_CHECK_RUN_ID: 12345678
+          INPUT_DEBUG: ""
+          INPUT_LABEL: ""
+          TRUNK_PATH: ../local-action/action_tests/stub.js
+          INPUT_GITHUB_REF_NAME: feature-branch
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ""
+          GITHUB_EVENT_PULL_REQUEST_BASE_SHA: ${{ env.EXPECTED_UPSTREAM }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ""
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FORK: ""
+          INPUT_SAVE_ANNOTATIONS: ""
+          INPUT_AUTOFIX_AND_PUSH: true
+          INPUT_TIMEOUT_SECONDS: 1
+
+      - name: Assert trunk-action check has failed
+        shell: bash
+        if: steps.trunk-action.outcome == 'success'
+        run: exit 1
+
   pull_request_autofix:
     runs-on: ubuntu-latest
     steps:

--- a/action.yaml
+++ b/action.yaml
@@ -274,7 +274,11 @@ runs:
       shell: bash
       run: |
         # Run 'trunk check' on pull request
-        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/pull_request.sh
+        if [[ "${{ inputs.timeout-seconds }}" != "0" ]]; then
+          timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/pull_request.sh
+        else
+          ${GITHUB_ACTION_PATH}/pull_request.sh
+        fi
       env:
         INPUT_SAVE_ANNOTATIONS: ${{ inputs.save-annotations }}
 
@@ -283,7 +287,11 @@ runs:
       shell: bash
       run: |
         # Run 'trunk check' on push
-        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/push.sh
+        if [[ "${{ inputs.timeout-seconds }}" != "0" ]]; then
+          timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/push.sh
+        else
+          ${GITHUB_ACTION_PATH}/push.sh
+        fi
       env:
         GITHUB_EVENT_AFTER: ${{ env.GITHUB_EVENT_AFTER || github.event.after }}
         GITHUB_EVENT_BEFORE: ${{ env.GITHUB_EVENT_BEFORE || github.event.before }}
@@ -293,14 +301,22 @@ runs:
       shell: bash
       run: |
         # Run 'trunk check' on all
-        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/all.sh
+        if [[ "${{ inputs.timeout-seconds }}" != "0" ]]; then
+          timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/all.sh
+        else
+          ${GITHUB_ACTION_PATH}/all.sh
+        fi
 
     - name: Run trunk check on Trunk Merge
       if: env.TRUNK_CHECK_MODE == 'trunk_merge'
       shell: bash
       run: |
         # Run 'trunk check' on Trunk Merge
-        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/trunk_merge.sh
+        if [[ "${{ inputs.timeout-seconds }}" != "0" ]]; then
+          timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/trunk_merge.sh
+        else
+          ${GITHUB_ACTION_PATH}/trunk_merge.sh
+        fi
 
     - name: Cat Trunk Cli / Daemon logs
       if: always() && inputs.cat-trunk-debug-logs == 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -102,6 +102,18 @@ inputs:
     required: false
     default: "false"
 
+  timeout-seconds:
+    description:
+      Timeout seconds before we kill the long running trunk check process via unix timeout command.
+      Default setting of 0 seconds disables the timeout.
+    required: false
+    default: 0
+
+  cat-trunk-debug-logs:
+    description: Option to cat .trunk/logs/cli.log && .trunk/logs/daemon.log
+    required: false
+    default: false
+
 runs:
   using: composite
   steps:
@@ -179,6 +191,7 @@ runs:
         INPUT_CACHE=${{ inputs.cache }}
         INPUT_CACHE_KEY=trunk-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
         INPUT_CACHE_PATH=~/.cache/trunk
+        INPUT_CAT_TRUNK_DEBUG_LOGS=${{ inputs.cat-trunk-debug-logs }}
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
         INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
@@ -189,6 +202,7 @@ runs:
         INPUT_SETUP_DEPS=${{ inputs.setup-deps }}
         INPUT_TARGET_CHECKOUT=
         INPUT_TARGET_CHECKOUT_REF=
+        INPUT_TIMEOUT_SECONDS=${{ inputs.timeout-seconds }}
         INPUT_TRUNK_PATH=${{ inputs.trunk-path }}
         INPUT_UPLOAD_LANDING_STATE=false
         INPUT_UPLOAD_SERIES=${{ inputs.upload-series }}
@@ -260,7 +274,7 @@ runs:
       shell: bash
       run: |
         # Run 'trunk check' on pull request
-        ${GITHUB_ACTION_PATH}/pull_request.sh
+        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/pull_request.sh
       env:
         INPUT_SAVE_ANNOTATIONS: ${{ inputs.save-annotations }}
 
@@ -269,7 +283,7 @@ runs:
       shell: bash
       run: |
         # Run 'trunk check' on push
-        ${GITHUB_ACTION_PATH}/push.sh
+        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/push.sh
       env:
         GITHUB_EVENT_AFTER: ${{ env.GITHUB_EVENT_AFTER || github.event.after }}
         GITHUB_EVENT_BEFORE: ${{ env.GITHUB_EVENT_BEFORE || github.event.before }}
@@ -279,14 +293,34 @@ runs:
       shell: bash
       run: |
         # Run 'trunk check' on all
-        ${GITHUB_ACTION_PATH}/all.sh
+        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/all.sh
 
     - name: Run trunk check on Trunk Merge
       if: env.TRUNK_CHECK_MODE == 'trunk_merge'
       shell: bash
       run: |
         # Run 'trunk check' on Trunk Merge
-        ${GITHUB_ACTION_PATH}/trunk_merge.sh
+        timeout ${{ inputs.timeout-seconds }} ${GITHUB_ACTION_PATH}/trunk_merge.sh
+
+    - name: Cat Trunk Cli / Daemon logs
+      if: always() && inputs.cat-trunk-debug-logs == 'true'
+      shell: bash
+      run: |
+        echo "::group::.trunk/logs/cli.log"
+        if [ -f .trunk/logs/cli.log ]; then
+          cat .trunk/logs/cli.log
+        else
+          echo ".trunk/logs/cli.log doesn't exist"
+        fi
+        echo "::endgroup::"
+
+        echo "::group::.trunk/logs/daemon.log"
+        if [ -f .trunk/logs/daemon.log ]; then
+          cat .trunk/logs/daemon.log
+        else
+          echo ".trunk/logs/daemon.log doesn't exist"
+        fi
+        echo "::endgroup::"
 
     - name: Run trunk install to populate the GitHub Actions cache
       if: env.TRUNK_CHECK_MODE == 'populate_cache_only'


### PR DESCRIPTION
There may be times where the trunk action is unresponsive and is hung in CI.
To understand whether this is a linter or trunk cli issue, we'll need logs to confirm.

This PR adds the following optional inputs `timeout-seconds` and `cat-trunk-debug-logs`
which will wrap the trunk check action with the unix `timeout` command should the user supply an argument for `timeout-seconds`

Should the user specify `cat-trunk-debug-logs: true`, the trunk action will also cat out cli & daemon logs from `.trunk/logs/`

Unfortunately, `timeout-minutes` doesn't work in `composite-actions` see https://github.com/actions/runner/issues/1979
and https://github.com/orgs/community/discussions/50481

**Test Plan**:
<details>

<summary>End to End test to ensure timeout + logs work</summary>

<img width="1873" alt="image" src="https://github.com/trunk-io/trunk-action/assets/31294356/27ca9a1b-fe54-4e73-928e-63625d1f934e">


</details>

<details>

<summary>End to End test to ensure timeout works </summary>

<img width="1878" alt="image" src="https://github.com/trunk-io/trunk-action/assets/31294356/8fb7351a-11c0-4e83-9490-864c6ecdafc0">



</details>

- [ ] Add Regression test (not entirely sure I can run this workflow) May need some help here!