### PR TITLE
fix: supress `trunk init` "blank" lines

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -236,7 +236,7 @@ runs:
       shell: bash
       run: |
         if [ ! -e .trunk/trunk.yaml ]; then
-          ${TRUNK_PATH:-trunk} init | grep -v -F -- "$(echo -e "\033[2K\033[0G")"
+          ${TRUNK_PATH:-trunk} --ci init
           echo "INITIALIZED_TRUNK=true" >>$GITHUB_ENV
         fi
 


### PR DESCRIPTION
The log then looks like this

```plain
2024-08-10T22:47:58.8716066Z [2K[0G
2024-08-10T22:47:59.0718541Z [2K[0G
2024-08-10T22:47:59.2719909Z [2K[0G
2024-08-10T22:47:59.4720633Z [2K[0G
2024-08-10T22:47:59.6722099Z [2K[0G
2024-08-10T22:47:59.8722445Z [2K[0G
2024-08-10T22:47:59.9751114Z [2K[0G
2024-08-10T22:48:00.1794815Z [2K[0G[0G
2024-08-10T22:48:00.3794984Z [2K[0G
2024-08-10T22:48:00.5797120Z [2K[0G
2024-08-10T22:48:00.7798352Z [2K[0G
2024-08-10T22:48:00.9799600Z [2K[0G
2024-08-10T22:48:01.1800856Z [2K[0G
2024-08-10T22:48:01.3802270Z [2K[0G
2024-08-10T22:48:01.5803572Z [2K[0G
2024-08-10T22:48:01.7804948Z [2K[0G
2024-08-10T22:48:01.9805564Z [2K[0G
2024-08-10T22:48:02.1806545Z [2K[0G
2024-08-10T22:48:02.2442270Z [2K[0G
2024-08-10T22:48:03.1623273Z [2K[0G[1m[32m
2024-08-10T22:48:03.1625751Z ✔ [0m[1m10 linters were enabled [0m[90m([0m[4m[90m.trunk/trunk.yaml[0m[90m)
```