### PR TITLE
(Fix): Default upstream ref to main

### DIFF
--- a/pull_request.sh
+++ b/pull_request.sh
@@ -31,7 +31,7 @@ if [[ -z ${upstream+x} ]]; then
   # Otherwise use github.event.pull_request.base.sha as the upstream.
   # The default 'main' can be overriden with 'arguments: --upstream=main'
   upstream="${GITHUB_EVENT_PULL_REQUEST_BASE_SHA:-main}"
-  git_commit="${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA}"
+  git_commit="${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA:-$(git rev-parse HEAD)}"
   fetch origin "${upstream}"
 fi
 

--- a/pull_request.sh
+++ b/pull_request.sh
@@ -29,7 +29,8 @@ fi
 
 if [[ -z ${upstream+x} ]]; then
   # Otherwise use github.event.pull_request.base.sha as the upstream.
-  upstream="${GITHUB_EVENT_PULL_REQUEST_BASE_SHA}"
+  # The default 'main' can be overriden with 'arguments: --upstream=main'
+  upstream="${GITHUB_EVENT_PULL_REQUEST_BASE_SHA:-main}"
   git_commit="${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA}"
   fetch origin "${upstream}"
 fi


### PR DESCRIPTION
This fix allows users to manually specify `check-mode: pull_request` and specify their own upstream to run in "pull request mode" from non-`pull_request` GH Workflow triggers.