### PR TITLE
chore: bump upload-artifact action dependency

### DIFF
--- a/.github/workflows/docker_repo_tests.yaml
+++ b/.github/workflows/docker_repo_tests.yaml
@@ -119,7 +119,7 @@ jobs:
             '${{ matrix.description }}'
 
       - name: Upload landing state
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.landing_state_artifact_name }} landing state
           path: .trunk/landing-state.json

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -182,7 +182,7 @@ jobs:
             '${{ matrix.description }}'
 
       - name: Upload landing state
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.landing_state_artifact_name }} landing state
           path: .trunk/landing-state.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -57,7 +57,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: SARIF file
           path: results.sarif

--- a/action.yaml
+++ b/action.yaml
@@ -360,7 +360,7 @@ runs:
 
     - name: Upload annotations artifact
       if: always() && env.TRUNK_UPLOAD_ANNOTATIONS == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: trunk-annotations
         path: ${{ env.TRUNK_TMPDIR }}/annotations.bin
@@ -409,7 +409,7 @@ runs:
     - name: Upload landing state
       if: env.INPUT_UPLOAD_LANDING_STATE == 'true'
       continue-on-error: true
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: landing-state.json
         path: .trunk/landing-state.json


### PR DESCRIPTION
actions/upload-artifact@v3 will be unusable in 2 months ([announcement link](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/))