### PR TITLE
feat(upgrade): update create-pull-request to v7 and add sign-commits input parameter

### DIFF
--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -91,8 +91,7 @@ outputs:
     value: ${{ steps.cpr.outputs.pull-request-url }}
 
   pull-request-operation:
-    description:
-      The pull request operation performed by the action, `created`, `updated` or `closed`.
+    description: The pull request operation performed by the action, `created`, `updated` or `closed`.
     value: ${{ steps.cpr.outputs.pull-request-operation }}
 
   pull-request-head-sha:

--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -80,6 +80,7 @@ inputs:
     description: A boolean to sign commits. See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signature-verification-for-bots
     required: false
     default: false
+
 outputs:
   pull-request-number:
     description: The pull request number
@@ -152,7 +153,7 @@ runs:
 
     - name: Create Pull Request
       id: cpr
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7
       with:
         title: ${{ inputs.prefix }}${{ env.PR_TITLE }}
         body: ${{ env.PR_DESCRIPTION }}
@@ -165,5 +166,6 @@ runs:
         assignees: ${{ inputs.assignees }}
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}
+        branch-token: ${{ inputs.github-token }}
         signoff: ${{ inputs.signoff }}
         sign-commits: ${{ inputs.sign-commits }}

--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -75,6 +75,11 @@ inputs:
     description: A boolean to add a Signed-off-by line to the commit message
     required: false
     default: false
+
+  sign-commits:
+    description: A boolean to sign commits. See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signature-verification-for-bots
+    required: false
+    default: false
 outputs:
   pull-request-number:
     description: The pull request number
@@ -161,3 +166,4 @@ runs:
         reviewers: ${{ inputs.reviewers }}
         token: ${{ inputs.github-token }}
         signoff: ${{ inputs.signoff }}
+        sign-commits: ${{ inputs.sign-commits }}

--- a/upgrade/action.yaml
+++ b/upgrade/action.yaml
@@ -77,7 +77,9 @@ inputs:
     default: false
 
   sign-commits:
-    description: A boolean to sign commits. See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signature-verification-for-bots
+    description:
+      A boolean to sign commits. See
+      https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signature-verification-for-bots
     required: false
     default: false
 
@@ -91,7 +93,8 @@ outputs:
     value: ${{ steps.cpr.outputs.pull-request-url }}
 
   pull-request-operation:
-    description: The pull request operation performed by the action, `created`, `updated` or `closed`.
+    description:
+      The pull request operation performed by the action, `created`, `updated` or `closed`.
     value: ${{ steps.cpr.outputs.pull-request-operation }}
 
   pull-request-head-sha:


### PR DESCRIPTION
I want to use automated trunk updates in a repository where all commits need to be signed. 

So I thought about adding it to the github action because the `create-pull-request` action that is used here has support for signed commits using GitHub API starting with v7.

So I upgraded `create-pull-request` to v7 and added a new input value to enable signing.

I am using my forked action currently and its working fine but I would like to contribute this to you :)