### PR TITLE
fix: Fix trunk.yaml lint error

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,3 +1,4 @@
+---
 version: 0.1
 
 cli:


### PR DESCRIPTION
- this file is causing my CI checks to fail because it fails yamllint