### PR TITLE
fix: only post comment when checking PRs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -267,8 +267,11 @@ runs:
 
     - name: Find Comment
       uses: peter-evans/find-comment@v3
-      if: inputs.check-mode == 'payload' && env.INPUT_GITHUB_TOKEN
+      if: |
+        inputs.check-mode == 'payload' && env.TRUNK_CHECK_MODE == 'pull_request' &&
+        env.INPUT_GITHUB_TOKEN
       id: fc
+      continue-on-error: true
       with:
         issue-number: ${{ env.GITHUB_EVENT_PULL_REQUEST_NUMBER }}
         repository: ${{ env.INPUT_TARGET_CHECKOUT }}
@@ -277,7 +280,10 @@ runs:
 
     - name: Post comment
       uses: peter-evans/create-or-update-comment@v4
-      if: inputs.check-mode == 'payload' && env.INPUT_GITHUB_TOKEN
+      if: |
+        inputs.check-mode == 'payload' && env.TRUNK_CHECK_MODE == 'pull_request' &&
+        env.INPUT_GITHUB_TOKEN
+      continue-on-error: true
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ env.GITHUB_EVENT_PULL_REQUEST_NUMBER }}


### PR DESCRIPTION
Changes the comment posting so it only happens on checking PRs, not on checking merge. Additionally, adds a continue on error, so that if there are future errors, they aren't blocking.