### PR TITLE
Remove the deprecation notice comment

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -265,34 +265,6 @@ runs:
           echo .trunk/setup-ci >>.git/info/exclude
         fi
 
-    - name: Find Comment
-      uses: peter-evans/find-comment@v3
-      if: |
-        inputs.check-mode == 'payload' && env.TRUNK_CHECK_MODE == 'pull_request' &&
-        env.INPUT_GITHUB_TOKEN
-      id: fc
-      continue-on-error: true
-      with:
-        issue-number: ${{ env.GITHUB_EVENT_PULL_REQUEST_NUMBER }}
-        repository: ${{ env.INPUT_TARGET_CHECKOUT }}
-        token: ${{ env.INPUT_GITHUB_TOKEN }}
-        body-regex: ^.*https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues/migration-guide.*$
-
-    - name: Post comment
-      uses: peter-evans/create-or-update-comment@v4
-      if: |
-        inputs.check-mode == 'payload' && env.TRUNK_CHECK_MODE == 'pull_request' &&
-        env.INPUT_GITHUB_TOKEN
-      continue-on-error: true
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ env.GITHUB_EVENT_PULL_REQUEST_NUMBER }}
-        repository: ${{ env.INPUT_TARGET_CHECKOUT }}
-        token: ${{ env.INPUT_GITHUB_TOKEN }}
-        edit-mode: replace
-        body: |
-          Running Code Quality on PRs by uploading data to Trunk will soon be removed. You can still run checks on your PRs using [trunk-action](https://github.com/trunk-io/trunk-action) - see the [migration guide](https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues/migration-guide) for more information.
-
     - name: Set up env
       uses: ./.trunk/setup-ci
       if: env.INPUT_SETUP_DEPS == 'true'

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 > **Note**
 >
 > We strongly encourage using Trunk Code Quality's integration with GitHub to run Trunk Code Quality
-> on CI. [Get started here!](https://docs.trunk.io/code-quality/ci-setup)
+> on CI. [Get started here!](https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues)
 
 This action runs and shows inline annotations of issues found by
 [Trunk Code Quality](https://docs.trunk.io/code-quality), a powerful meta linter and formatter.
@@ -36,7 +36,7 @@ tier for team use in private repos. (See [pricing](https://trunk.io/pricing))
 
 ## Get Started
 
-[Follow these instructions to set up Trunk Code Quality CI for your GitHub repository](https://docs.trunk.io/code-quality/ci-setup)
+[Follow these instructions to set up Trunk Code Quality CI for your GitHub repository](https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues)
 
 ## Run it Yourself
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@
 > **Note**
 >
 > We strongly encourage using Trunk Code Quality's integration with GitHub to run Trunk Code Quality
-> on CI. [Get started here!](https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues)
+> on CI.
+> [Get started here!](https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues)
 
 This action runs and shows inline annotations of issues found by
 [Trunk Code Quality](https://docs.trunk.io/code-quality), a powerful meta linter and formatter.


### PR DESCRIPTION
This PR removes the deprecation notice comment that's posted on new PRs, as it's been 4 months and the new frontend doesn't have an option to disable it anymore. Also fix link to docs page in README. 

<img width="956" height="192" alt="Screenshot 2025-09-08 at 11 45 32 AM" src="https://github.com/user-attachments/assets/6728a521-8ebe-4f34-b931-d75ee4aca3c2" />