### PR TITLE
actions/cache@v4 is deprecated

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -278,7 +278,7 @@ runs:
 
     - name: Cache Linters/Formatters
       if: env.TRUNK_CHECK_MODE != 'none' && env.INPUT_CACHE == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.INPUT_CACHE_PATH }}
         key: ${{ env.INPUT_CACHE_KEY }}


### PR DESCRIPTION
actions/cache@v4 is deprecated because of migration to nodejs 24 https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/