### PR TITLE
Refresh docker repo-test refs to track current upstream state

### DIFF
--- a/.github/workflows/docker_repo_tests.yaml
+++ b/.github/workflows/docker_repo_tests.yaml
@@ -26,7 +26,8 @@ jobs:
           #     this workflow on PRs
           #
           - repo: highlightjs/highlight.js
-            ref: 4f9cd3bffb6bc55c9e2c4252c7b733a219880151
+            # Keep this on main so Docker CI continuously validates current npm + trunk init behavior.
+            ref: main
             description: (uses npm)
             post-init: |
               # terrascan scans dockerfile.js (a JS file for parsing dockerfiles) as a dockerfile itself
@@ -35,7 +36,8 @@ jobs:
             cache: true
 
           - repo: pallets/flask
-            ref: 4bcd4be6b7d69521115ef695a379361732bcaea6
+            # Keep this on main so Docker CI catches Python ecosystem drift quickly.
+            ref: main
             post-init: |
               # prettier chokes on this malformed html file
               echo "examples/celery/src/task_app/templates/index.html" >> .gitignore
@@ -68,7 +70,8 @@ jobs:
             cache: false
 
           - repo: sass/sass
-            ref: 225e176115211387e014d97ae0076d94de3152a1
+            # Keep this on main so Docker CI validates current npm toolchain behavior.
+            ref: main
             description: (uses npm)
             cache: true
 


### PR DESCRIPTION
### Motivation
- Docker-based repo tests were pinned to older SHAs and no longer exercised current toolchains, causing stale smoke coverage for `trunk-action` validation.
- The intent is to keep these Docker smoke tests healthy so `trunk init` and the action are validated against modern upstream ecosystems.

### Description
- Updated `.github/workflows/docker_repo_tests.yaml` to replace historical SHAs with `ref: main` for `highlightjs/highlight.js`, `pallets/flask`, and `sass/sass` to track current upstream state.
- Added inline comments explaining why these three Docker entries should stay on `main` as ongoing smoke checks.
- Left the `postcss/postcss` Docker entry and its deliberate pin strategy unchanged.

### Testing
- Ran `git diff -- .github/workflows/docker_repo_tests.yaml` to verify the produced diff, which succeeded.
- Ran `git status --short` and `git commit -m "Refresh docker repo test refs to track current upstream"` to commit the change, which succeeded.
- Generated the PR body with `make_pr`, which produced the PR title and description for review; no CI workflows were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04c5e5bfbc832d8b7282b368b9b775)