### PR TITLE
Remove defunct CheckService annotation path

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -30,7 +30,6 @@ jobs:
           ../local-action/trunk_merge.sh
         env:
           INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: ""
           INPUT_DEBUG: ""
           INPUT_LABEL: ""
           TRUNK_PATH: ../local-action/action_tests/stub.js
@@ -41,158 +40,6 @@ jobs:
           cd local-action
           npm install
           ./action_tests/assert.js trunk-merge
-
-  trunk-merge-annotate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: local-action
-
-      - name: Set up test
-        shell: bash
-        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
-
-      - name: Run trunk-action
-        shell: bash
-        run: |
-          cd repo-under-test
-          git checkout trunk-merge/of-feature-branch
-          echo "EXPECTED_UPSTREAM=$(git rev-parse trunk-merge/of-feature-branch^1)" >>$GITHUB_ENV
-          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse trunk-merge/of-feature-branch^2)" >>$GITHUB_ENV
-          ../local-action/trunk_merge.sh
-        env:
-          INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: "8675309"
-          INPUT_DEBUG: ""
-          INPUT_LABEL: ""
-          TRUNK_PATH: ../local-action/action_tests/stub.js
-
-      - name: Assert CLI calls
-        shell: bash
-        run: |
-          cd local-action
-          npm install
-          ./action_tests/assert.js trunk-merge-annotate
-
-  trunk-merge-annotate-old-cli:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: local-action
-
-      - name: Set up test
-        shell: bash
-        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
-
-      - name: Run trunk-action
-        shell: bash
-        run: |
-          cd repo-under-test
-          git checkout trunk-merge/of-feature-branch
-          echo "EXPECTED_UPSTREAM=$(git rev-parse trunk-merge/of-feature-branch^1)" >>$GITHUB_ENV
-          echo "EXPECTED_GITHUB_COMMIT=$(git rev-parse trunk-merge/of-feature-branch^2)" >>$GITHUB_ENV
-          ../local-action/trunk_merge.sh
-        env:
-          INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: "8675309"
-          INPUT_DEBUG: ""
-          INPUT_LABEL: ""
-          TRUNK_PATH: ../local-action/action_tests/stub.js
-          TRUNK_CLI_VERSION: 1.6.0
-        continue-on-error: true
-
-      - name: Assert CLI calls
-        shell: bash
-        run: |
-          cd local-action
-          npm install
-          ./action_tests/assert.js trunk-merge-annotate-old-cli
-
-  pull-request-trunk-annotate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: local-action
-
-      - name: Set up test
-        shell: bash
-        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
-
-      - name: Run trunk-action
-        shell: bash
-        run: |
-          cd repo-under-test
-          git checkout feature-branch
-          export GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=$(git rev-parse feature-branch)
-          export GITHUB_EVENT_PULL_REQUEST_BASE_SHA=$(git rev-parse main)
-          echo "EXPECTED_UPSTREAM=${GITHUB_EVENT_PULL_REQUEST_BASE_SHA}" >>$GITHUB_ENV
-          echo "EXPECTED_GITHUB_COMMIT=${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA}" >>$GITHUB_ENV
-          ../local-action/pull_request.sh
-        env:
-          INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: "8675309"
-          INPUT_DEBUG: ""
-          INPUT_LABEL: ""
-          INPUT_SAVE_ANNOTATIONS: ""
-          INPUT_GITHUB_REF_NAME: feature_branch
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: "1337"
-          TRUNK_PATH: ../local-action/action_tests/stub.js
-          INPUT_AUTOFIX_AND_PUSH: ""
-
-      - name: Assert CLI calls
-        shell: bash
-        run: |
-          cd local-action
-          npm install
-          ./action_tests/assert.js pull-request-trunk-annotate
-
-  pull-request-trunk-annotate-old-cli:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: local-action
-
-      - name: Set up test
-        shell: bash
-        run: ./local-action/action_tests/setup.sh src-repo repo-under-test
-
-      - name: Run trunk-action
-        shell: bash
-        run: |
-          cd repo-under-test
-          git checkout feature-branch
-          export GITHUB_EVENT_PULL_REQUEST_HEAD_SHA=$(git rev-parse feature-branch)
-          export GITHUB_EVENT_PULL_REQUEST_BASE_SHA=$(git rev-parse main)
-          echo "EXPECTED_UPSTREAM=${GITHUB_EVENT_PULL_REQUEST_BASE_SHA}" >>$GITHUB_ENV
-          echo "EXPECTED_GITHUB_COMMIT=${GITHUB_EVENT_PULL_REQUEST_HEAD_SHA}" >>$GITHUB_ENV
-          ../local-action/pull_request.sh
-        env:
-          INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: "8675309"
-          INPUT_DEBUG: ""
-          INPUT_LABEL: ""
-          INPUT_SAVE_ANNOTATIONS: ""
-          INPUT_GITHUB_REF_NAME: feature_branch
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: "1337"
-          TRUNK_PATH: ../local-action/action_tests/stub.js
-          INPUT_AUTOFIX_AND_PUSH: ""
-          TRUNK_CLI_VERSION: 1.6.0
-        continue-on-error: true
-
-      - name: Assert CLI calls
-        shell: bash
-        run: |
-          cd local-action
-          npm install
-          ./action_tests/assert.js pull-request-trunk-annotate-old-cli
 
   pull-request-github-annotate-file:
     runs-on: ubuntu-latest
@@ -218,7 +65,6 @@ jobs:
           ../local-action/pull_request.sh
         env:
           INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: ""
           INPUT_DEBUG: ""
           INPUT_LABEL: ""
           INPUT_GITHUB_REF_NAME: feature_branch
@@ -260,7 +106,6 @@ jobs:
           ../local-action/pull_request.sh
         env:
           INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: ""
           INPUT_DEBUG: ""
           INPUT_LABEL: ""
           INPUT_SAVE_ANNOTATIONS: ""
@@ -452,7 +297,6 @@ jobs:
           fi
         env:
           INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: 12345678
           INPUT_DEBUG: ""
           INPUT_LABEL: ""
           TRUNK_PATH: ../local-action/action_tests/stub.js
@@ -490,7 +334,6 @@ jobs:
           ../local-action/pull_request.sh
         env:
           INPUT_ARGUMENTS: ""
-          INPUT_CHECK_RUN_ID: 12345678
           INPUT_DEBUG: ""
           INPUT_LABEL: ""
           TRUNK_PATH: ../local-action/action_tests/stub.js

--- a/.github/workflows/repo_tests.yaml
+++ b/.github/workflows/repo_tests.yaml
@@ -90,22 +90,6 @@ jobs:
               fi
             description: (test for continuing on node package install failure)
 
-          - repo: replayio/devtools
-            ref: 730a9f0ddaafefc2a1a293d6924ce3910cd156ac
-            description: (has trunk.yaml)
-            pre-init: |
-              # Avoid postinstall hooks that download Replay/Playwright browsers during yarn install.
-              echo "YARN_ENABLE_SCRIPTS=false" >> "$GITHUB_ENV"
-            post-init: |
-              # replay is on a very old version
-              # trunk upgrade requires 3 calls to guarantee correctness
-              ${TRUNK_PATH} upgrade
-              ${TRUNK_PATH} upgrade
-              ${TRUNK_PATH} upgrade
-              # Post-upgrade Prettier 3.x crashes on this snapshot; test covers trunk upgrade only.
-              ${TRUNK_PATH} check disable prettier
-            trunk-path: node_modules/.bin/trunk
-
           - repo: sass/sass
             ref: 225e176115211387e014d97ae0076d94de3152a1
             description: (uses npm)
@@ -151,13 +135,13 @@ jobs:
 
     steps:
       - name: Checkout ${{ matrix.repo }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ matrix.repo }}
           ref: ${{ matrix.ref }}
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: local-action
 
@@ -172,7 +156,6 @@ jobs:
         with:
           cache: true
           check-mode: all
-          trunk-path: ${{ matrix.trunk-path }}
           post-init: ${{ matrix.post-init }}
           arguments: --output-file=/tmp/landing-state.json
           cache-key: repo_tests/${{ matrix.repo }}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,7 +6,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.9.0
+      ref: v1.11.0
       uri: https://github.com/trunk-io/plugins
     - id: configs
       ref: v1.2.1
@@ -27,8 +27,9 @@ lint:
       level: medium
   # enabled list inherited from plugin 'configs'
   enabled:
-    - zizmor@1.24.1
-    - grype@0.112.0
+    - pinact@4.1.1
+    - zizmor@1.29.0
+    - grype@0.116.1
   disabled:
     - semgrep
     - eslint
@@ -39,7 +40,7 @@ lint:
 runtimes:
   enabled:
     - go@1.21.0
-    - node@22.16.0
+    - node@24.18.1
     - python@3.14.4
 actions:
   enabled:

--- a/action.yaml
+++ b/action.yaml
@@ -37,10 +37,6 @@ inputs:
     required: false
     default: ""
 
-  check-run-id:
-    description: Check run ID. If set, posts annotations using CheckService.
-    required: false
-
   cache:
     description:
       Cache trunk downloads and results between runs. Caching is only needed when using ephemeral CI
@@ -173,7 +169,6 @@ runs:
         INPUT_CACHE_PATH=$(payload cachePath)
         INPUT_CHECK_ALL_MODE=$(payload checkAllMode)
         INPUT_CHECK_MODE=$(payload checkMode)
-        INPUT_CHECK_RUN_ID=$(payload checkRunId)
         INPUT_DEBUG=$(payload debug)
         INPUT_GITHUB_REF_NAME=$(payload targetRefName)
         INPUT_LABEL=$(payload label)
@@ -207,7 +202,6 @@ runs:
         INPUT_CAT_TRUNK_DEBUG_LOGS=${{ inputs.cat-trunk-debug-logs }}
         INPUT_CHECK_ALL_MODE=${{ inputs.check-all-mode }}
         INPUT_CHECK_MODE=${{ inputs.check-mode }}
-        INPUT_CHECK_RUN_ID=${{ inputs.check-run-id }}
         INPUT_DEBUG=${{ inputs.debug }}
         INPUT_GITHUB_REF_NAME=${{ github.ref_name }}
         INPUT_LABEL=${{ inputs.label }}

--- a/action_tests/assert.js
+++ b/action_tests/assert.js
@@ -12,17 +12,22 @@ const stubLog = fs.readFileSync(process.env.TRUNK_STUB_LOGS, "utf8").split("\n")
 expect(stubLog.slice(-1)).to.deep.equal([""]);
 
 const getHtlFactoriesPath = () => {
-  const tmpdirContents = fs.readdirSync(process.env.TMPDIR);
+  // all.sh creates the htl factories file via `mktemp`, which names it `tmp.XXXXXX`.
+  // Ignore anything else (e.g. Node's `node-compile-cache` directory, which newer Node
+  // versions drop into TMPDIR).
+  const tmpdirContents = fs
+    .readdirSync(process.env.TMPDIR)
+    .filter((entry) => entry.startsWith("tmp."));
 
   if (tmpdirContents.length === 0) {
     throw new Error(
-      `TMPDIR=${process.env.TMPDIR} was empty; could not infer what --htl-factories-path should have been`,
+      `TMPDIR=${process.env.TMPDIR} had no mktemp entries; could not infer what --htl-factories-path should have been`,
     );
   }
 
   if (tmpdirContents.length > 1) {
     throw new Error(
-      `TMPDIR=${process.env.TMPDIR} had multiple entries (${JSON.stringify(
+      `TMPDIR=${process.env.TMPDIR} had multiple mktemp entries (${JSON.stringify(
         tmpdirContents,
       )}); could not infer what --htl-factories-path should have been`,
     );
@@ -45,38 +50,6 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       "",
     ],
   ],
-  "trunk-merge-annotate": () => [
-    ["trunk", "version"],
-    [
-      "trunk",
-      "check",
-      "--ci",
-      "--upstream",
-      process.env.EXPECTED_UPSTREAM,
-      "--github-commit",
-      process.env.EXPECTED_GITHUB_COMMIT,
-      "--github-label",
-      "",
-      "--trunk-annotate=8675309",
-    ],
-  ],
-  "trunk-merge-annotate-old-cli": () => [["trunk", "version"]],
-  "pull-request-trunk-annotate": () => [
-    ["trunk", "version"],
-    [
-      "trunk",
-      "check",
-      "--ci",
-      "--upstream",
-      process.env.EXPECTED_UPSTREAM,
-      "--github-commit",
-      process.env.EXPECTED_GITHUB_COMMIT,
-      "--github-label",
-      "",
-      "--trunk-annotate=8675309",
-    ],
-  ],
-  "pull-request-trunk-annotate-old-cli": () => [["trunk", "version"]],
   "pull-request-github-annotate-file": () => [
     [
       "trunk",
@@ -144,7 +117,6 @@ const EXPECTED_CLI_CALL_FACTORIES = {
     ["trunk", "check", "--all", "--upload", "--series", "series-name"],
   ],
   "pull-request-autofix": () => [
-    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -152,13 +124,12 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       "--upstream",
       process.env.EXPECTED_UPSTREAM,
       "--fix",
-      "--trunk-annotate=12345678",
+      "--github-annotate",
     ],
   ],
   "pull-request-payload": () => [
     ["trunk", "version"],
     ["trunk", "--ci", "init"],
-    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -169,13 +140,12 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       process.env.EXPECTED_GITHUB_COMMIT,
       "--github-label",
       "",
-      "--trunk-annotate=14235603498",
+      "--github-annotate",
     ],
   ],
   "trunk-merge-payload": () => [
     ["trunk", "version"],
     ["trunk", "--ci", "init"],
-    ["trunk", "version"],
     [
       "trunk",
       "check",
@@ -186,7 +156,6 @@ const EXPECTED_CLI_CALL_FACTORIES = {
       process.env.EXPECTED_GITHUB_COMMIT,
       "--github-label",
       "",
-      "--trunk-annotate=14235603498",
     ],
   ],
   "all-payload": () => [

--- a/action_tests/pull_request_test_payload.json
+++ b/action_tests/pull_request_test_payload.json
@@ -15,7 +15,6 @@
       "ref": "main"
     }
   },
-  "checkRunId": 14235603498,
   "version": "0.0.0",
   "githubToken": "fake-token",
   "cache": true,

--- a/action_tests/trunk_merge_test_payload.json
+++ b/action_tests/trunk_merge_test_payload.json
@@ -4,7 +4,6 @@
   "targetCheckoutRef": "refs/heads/trunk-merge/of-feature-branch",
   "checkMode": "trunk_merge",
   "trunkToken": "fake-token",
-  "checkRunId": 14235603498,
   "version": "0.0.0",
   "githubToken": "fake-token",
   "cache": true,

--- a/pull_request.sh
+++ b/pull_request.sh
@@ -15,8 +15,6 @@ fetch() {
     "$@"
 }
 
-MINIMUM_CHECK_RUN_ID_VERSION=1.7.0
-
 if [[ ${INPUT_GITHUB_REF_NAME} == "${GITHUB_EVENT_PULL_REQUEST_NUMBER}/merge" ]]; then
   # If we have checked out the merge commit then fetch enough history to use HEAD^1 as the upstream.
   # We use this instead of github.event.pull_request.base.sha which can be incorrect sometimes.
@@ -40,20 +38,7 @@ if [[ ${save_annotations} == "auto" && ${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FOR
   save_annotations=true
 fi
 
-if [[ -n ${INPUT_CHECK_RUN_ID} ]]; then
-  trunk_version="$(${TRUNK_PATH} version)"
-  # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
-  if sort_result=$(printf "%s\n%s\n" "${MINIMUM_CHECK_RUN_ID_VERSION}" "${trunk_version}" | sort --version-sort); then
-    if [[ $(echo "${sort_result}" | head -n 1) == "${trunk_version}" ]]; then
-      echo "::error::Please update your CLI to ${MINIMUM_CHECK_RUN_ID_VERSION} or higher (current version ${trunk_version})."
-      exit 1
-    fi
-  else
-    echo "::warning::sort --version-sort failed - continuing without checking CLI version"
-  fi
-  # trunk-ignore-end(shellcheck/SC2312)
-  annotation_argument=--trunk-annotate=${INPUT_CHECK_RUN_ID}
-elif [[ ${save_annotations} == "true" ]]; then
+if [[ ${save_annotations} == "true" ]]; then
   annotation_argument=--github-annotate-file=${TRUNK_TMPDIR}/annotations.bin
   # Signal that we need to upload an annotations artifact
   echo "TRUNK_UPLOAD_ANNOTATIONS=true" >>"${GITHUB_ENV}"

--- a/repo_tests/postcss.yaml
+++ b/repo_tests/postcss.yaml
@@ -4,3 +4,6 @@ lint:
     - trivy
     # Hermetic ESLint 10.x crashes on this snapshot (flat config / scopeManager); smoke test targets pnpm + trunk, not eslint.
     - eslint
+    # oxlint/oxfmt evaluate postcss's oxfmt.config.ts, which imports @logux/oxc-configs — a package that
+    # isn't resolvable in trunk's hermetic tool runtime. Smoke test targets pnpm + trunk, not oxlint.
+    - oxlint

--- a/trunk_merge.sh
+++ b/trunk_merge.sh
@@ -15,35 +15,15 @@ fetch() {
     "$@"
 }
 
-MINIMUM_CHECK_RUN_ID_VERSION=1.7.0
-
 head_sha=$(git rev-parse HEAD)
 fetch --depth=2 origin "${head_sha}"
 upstream=$(git rev-parse HEAD^1)
 git_commit=$(git rev-parse HEAD^2)
 echo "Detected merge queue commit, using HEAD^1 (${upstream}) as upstream and HEAD^2 (${git_commit}) as github commit"
 
-if [[ -n ${INPUT_CHECK_RUN_ID} ]]; then
-  trunk_version="$(${TRUNK_PATH} version)"
-  # trunk-ignore-begin(shellcheck/SC2312): the == will fail if anything inside the $() fails
-  if sort_result=$(printf "%s\n%s\n" "${MINIMUM_CHECK_RUN_ID_VERSION}" "${trunk_version}" | sort --version-sort); then
-    if [[ $(echo "${sort_result}" | head -n 1) == "${trunk_version}" ]]; then
-      echo "::error::Please update your CLI to ${MINIMUM_CHECK_RUN_ID_VERSION} or higher (current version ${trunk_version})."
-      exit 1
-    fi
-  else
-    echo "::warning::sort --version-sort failed - continuing without checking CLI version"
-  fi
-  # trunk-ignore-end(shellcheck/SC2312)
-  annotation_argument=--trunk-annotate=${INPUT_CHECK_RUN_ID}
-else
-  annotation_argument=""
-fi
-
 "${TRUNK_PATH}" check \
   --ci \
   --upstream "${upstream}" \
   --github-commit "${git_commit}" \
   --github-label "${INPUT_LABEL}" \
-  ${annotation_argument} \
   ${INPUT_ARGUMENTS}


### PR DESCRIPTION
## Summary

Removes the defunct **CheckService** annotation path (`check-run-id` / `--trunk-annotate`). Trunk no longer supports CheckService, so that path can never authenticate — it fails with `Failed to post annotations to github: [UNAUTHENTICATED] No session provided`. This PR rips it out and folds in the CI maintenance needed to get the suite green again.

## Changes

### Core: remove CheckService annotation path
- **`action.yaml`** — remove the `check-run-id` input and its `INPUT_CHECK_RUN_ID` env wiring (both the `payload` and non-payload blocks). Also drops the internal `checkRunId` payload field.
- **`pull_request.sh`** — delete the `INPUT_CHECK_RUN_ID` branch (and its `MINIMUM_CHECK_RUN_ID_VERSION` CLI-version gate). Annotation selection is now just: fork / `save-annotations` -> `--github-annotate-file`, otherwise `--github-annotate`. Autofix runs now post via `--github-annotate` too.
- **`trunk_merge.sh`** — delete the CheckService branch. Trunk Merge runs now invoke `trunk check` with no annotation flag (they previously only annotated via CheckService).
- **`action_tests/*`** — remove the now-dead `checkRunId` payload fixtures and the `*-trunk-annotate*` action-test jobs / `assert.js` expectations; update `pull-request-payload`, `trunk-merge-payload`, and `pull-request-autofix` expectations to the `--github-annotate` (or no-annotation) output.

### CI maintenance (surfaced while getting this green)
- **Upgrade trunk plugins** (source `v1.11.0`, `zizmor`, `grype`) and **enable `pinact`** (`.trunk/trunk.yaml`).
- **Move the trunk node runtime to the Node 24 LTS line** (`node@22.16.0` -> `node@24.18.1`) in `.trunk/trunk.yaml`.
- **`action_tests/assert.js`** — ignore Node's `node-compile-cache` directory in the `all-hold-the-line` tests' htl-factories-path lookup (newer Node drops that dir into `TMPDIR`, which broke the single-entry assumption).
- **`.github/workflows/repo_tests.yaml`** — remove the slow `replayio/devtools` matrix entry and the now-unused `matrix.trunk-path` passthrough.
- **`repo_tests/postcss.yaml`** — disable `oxlint` for the postcss repo test. Its `oxfmt.config.ts` imports `@logux/oxc-configs`, which isn't resolvable in trunk's hermetic tool runtime (this is a package-resolution issue, not a Node-version issue — it fails on Node 24 too).

## Breaking-change assessment

Not breaking in practice, though it does remove one public input:
- **Removed input:** `check-run-id` (and the internal `checkRunId` payload field).
- GitHub silently ignores undeclared `with:` inputs on composite actions, so workflows still passing `check-run-id` won't error — they just fall back to `--github-annotate`.
- The removed path was already non-functional (CheckService is gone), so no working behavior is lost.
- If released under a semver major tag, note the `check-run-id` removal in the release notes.

## Test plan
- [x] `action_tests` suite passes (updated stub-CLI expectations)
- [x] `Repository tests` + `Repository tests (docker)` pass, including postcss
- [x] `Trunk Check` / `Trunk Check Runner` pass on Node 24
- [ ] Confirm a normal PR run posts inline annotations with `checks: write`
- [ ] Confirm a fork PR still uploads the annotations artifact